### PR TITLE
Shared config support

### DIFF
--- a/apictl/Makefile
+++ b/apictl/Makefile
@@ -8,7 +8,7 @@ gensrc:
 	rm -f $(VERSIONFILE)
 	@echo "package cmd" > $(VERSIONFILE)
 	@echo "const (" >> $(VERSIONFILE)
-	@echo "  VERSION = \"0.1alpha\"" >> $(VERSIONFILE)
+	@echo "  VERSION = \"0.1-alpha\"" >> $(VERSIONFILE)
 	@echo "  BUILD_DATE = \"$(BUILD_DATE)\"" >> $(VERSIONFILE)
 	@echo "  GIT_COMMIT = \"$(GIT_COMMIT)\"" >> $(VERSIONFILE)
 	@echo "  GIT_TAG = \"$(GIT_TAG)\"" >> $(VERSIONFILE)

--- a/apictl/Makefile
+++ b/apictl/Makefile
@@ -2,7 +2,7 @@ BUILD_DATE := `date +%Y-%m-%d\ %H:%M`
 GIT_COMMIT := `git rev-parse \"HEAD^{commit}\"`
 GIT_TAG := `git describe --tags --abbrev=14`
 VERSIONFILE := cmd/clientVersion.go
-APP := ndslasctl
+APP := ndslabsctl
 
 gensrc:
 	rm -f $(VERSIONFILE)

--- a/apictl/cmd/clientVersion.go
+++ b/apictl/cmd/clientVersion.go
@@ -1,7 +1,7 @@
 package cmd
 const (
-  VERSION = "0.1alpha"
-  BUILD_DATE = "2016-03-25 08:57"
-  GIT_COMMIT = "d2762e56e126d40b9a9188f998f111a76a5b19ef"
+  VERSION = "0.1-alpha"
+  BUILD_DATE = "2016-03-25 17:16"
+  GIT_COMMIT = "8dfd2d867c5dd79e7132fa342f3fc80e8d7cca5a"
   GIT_TAG = ""
 )

--- a/apictl/cmd/clientVersion.go
+++ b/apictl/cmd/clientVersion.go
@@ -1,7 +1,7 @@
 package cmd
 const (
   VERSION = "0.1alpha"
-  BUILD_DATE = "2016-03-24 14:01"
-  GIT_COMMIT = "153a3f51bc442c6099f88ddc7d84c2bed68f787c"
+  BUILD_DATE = "2016-03-25 08:57"
+  GIT_COMMIT = "d2762e56e126d40b9a9188f998f111a76a5b19ef"
   GIT_TAG = ""
 )

--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER willis8@illinois.edu
 
 RUN apt-get update -y && apt-get install -y curl git
 
-COPY build/bin/amd64/apiserver /
+COPY build/bin/apiserver-linux-amd64 /apiserver
 COPY entrypoint.sh /
 
 VOLUME /volumes

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -1,5 +1,6 @@
 BUILD_DATE := `date +%Y-%m-%d\ %H:%M`
 VERSIONFILE := version.go
+APP := apiserver
 
 gensrc:
 	rm -f $(VERSIONFILE)
@@ -8,8 +9,9 @@ gensrc:
 	@echo "  VERSION = \"0.1alpha\"" >> $(VERSIONFILE)
 	@echo "  BUILD_DATE = \"$(BUILD_DATE)\"" >> $(VERSIONFILE)
 	@echo ")" >> $(VERSIONFILE)
-	rm -f build/bin/amd64/apictl build/bin/darwin/apictl
-	mkdir -p build/bin/amd64 build/bin/darwin build/pkg
+	rm -f build/bin/$(APP)-linux-amd64 build/$(APP)-darwin-amd64
+	mkdir -p build/bin build/bin build/pkg
+	GOOS=darwin GOARCH=amd64 go build -o build/bin/$(APP)-darwin-amd64
 	docker run --rm -it -v `pwd`:/go/src/github.com/ndslabs/apiserver -v `pwd`/build/bin:/go/bin -v `pwd`/build/pkg:/go/pkg -v `pwd`/build.sh:/build.sh golang  /build.sh
 	docker build -t ndslabs/apiserver:latest .
 	docker push ndslabs/apiserver:latest

--- a/apiserver/Makefile
+++ b/apiserver/Makefile
@@ -6,7 +6,7 @@ gensrc:
 	rm -f $(VERSIONFILE)
 	@echo "package main" > $(VERSIONFILE)
 	@echo "const (" >> $(VERSIONFILE)
-	@echo "  VERSION = \"0.1alpha\"" >> $(VERSIONFILE)
+	@echo "  VERSION = \"0.1-alpha\"" >> $(VERSIONFILE)
 	@echo "  BUILD_DATE = \"$(BUILD_DATE)\"" >> $(VERSIONFILE)
 	@echo ")" >> $(VERSIONFILE)
 	rm -f build/bin/$(APP)-linux-amd64 build/$(APP)-darwin-amd64

--- a/apiserver/build.sh
+++ b/apiserver/build.sh
@@ -3,4 +3,4 @@
 cd /go/src/github.com/ndslabs/apiserver
 go get
 #go build -ldflags "-X main.Version=0.1alpha -X main.BuildDate=`date "+%Y-%m-%dT%H:%M:%S"`"
-GOOS=linux GOARCH=amd64 go build -o build/bin/amd64/apiserver
+GOOS=linux GOARCH=amd64 go build -o build/bin/apiserver-linux-amd64

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -483,7 +483,7 @@ func (k *KubeHelper) CreateServiceTemplate(name string, stack string, spec *ndsa
 	return &k8svc
 }
 
-func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack string, stackService *ndsapi.StackService, spec *ndsapi.ServiceSpec, links *map[string]ServiceAddrPort) *api.ReplicationController {
+func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack string, stackService *ndsapi.StackService, spec *ndsapi.ServiceSpec, links *map[string]ServiceAddrPort, sharedEnv *map[string]string) *api.ReplicationController {
 
 	k8rc := api.ReplicationController{}
 	// Replication controller
@@ -497,6 +497,7 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 	}
 
 	env := []api.EnvVar{}
+	env = append(env, api.EnvVar{Name: "NAMESPACE", Value: ns})
 
 	for name, addrPort := range *links {
 
@@ -512,7 +513,6 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 			continue
 		}
 
-		env = append(env, api.EnvVar{Name: "NAMESPACE", Value: ns})
 		env = append(env,
 			api.EnvVar{
 				Name:  fmt.Sprintf("%s_PORT_%d_TCP_ADDR", strings.ToUpper(name), addrPort.Port),
@@ -534,6 +534,10 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 				value = val
 			}
 		}
+		env = append(env, api.EnvVar{Name: name, Value: value})
+	}
+
+	for name, value := range *sharedEnv {
 		env = append(env, api.EnvVar{Name: name, Value: value})
 	}
 

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -474,9 +474,8 @@ func (k *KubeHelper) CreateServiceTemplate(name string, stack string, spec *ndsa
 				Name: fmt.Sprintf("%d", port.Port),
 				Port: port.Port,
 			}
-			if port.Protocol == "TCP" {
-				k8port.Protocol = api.ProtocolTCP
-			}
+			// For now, assume all ports are TCP
+			k8port.Protocol = api.ProtocolTCP
 			k8svc.Spec.Ports = append(k8svc.Spec.Ports, k8port)
 		}
 	}

--- a/apiserver/types/types.go
+++ b/apiserver/types/types.go
@@ -84,6 +84,7 @@ type Service struct {
 type ServiceDependency struct {
 	DependencyKey string `json:"key"`
 	Required      bool   `json:"required"`
+	ShareConfig   bool   `json:"shareConfig"`
 }
 
 type Stack struct {

--- a/apiserver/version.go
+++ b/apiserver/version.go
@@ -1,5 +1,5 @@
 package main
 const (
   VERSION = "0.1alpha"
-  BUILD_DATE = "2016-03-25 09:24"
+  BUILD_DATE = "2016-03-25 12:19"
 )

--- a/apiserver/version.go
+++ b/apiserver/version.go
@@ -1,5 +1,5 @@
 package main
 const (
   VERSION = "0.1alpha"
-  BUILD_DATE = "2016-03-24 14:03"
+  BUILD_DATE = "2016-03-25 09:24"
 )

--- a/apiserver/version.go
+++ b/apiserver/version.go
@@ -1,5 +1,5 @@
 package main
 const (
-  VERSION = "0.1alpha"
-  BUILD_DATE = "2016-03-25 12:19"
+  VERSION = "0.1-alpha"
+  BUILD_DATE = "2016-03-25 17:16"
 )


### PR DESCRIPTION
Added "shared config" support to the service spec. This way, a dependent service can access configuration information from another service (e.g., Dataverse can access the iCAT user/password instead of the user needing to add it twice).   Additional changes to the go binary naming conventions -- os/arch in the binary name instead of the path.