### PR TITLE
NDS-219: Change API server to use Kubernetes token authentication

### DIFF
--- a/apiserver/apiserver.conf
+++ b/apiserver/apiserver.conf
@@ -3,10 +3,9 @@ Port=30001
 Origin=
 VolDir=/tmp/volumes
 VolumeSource=local
-#Timeout=1
 
 [Etcd]
 Address=localhost:4001
+
 [Kubernetes]
 Address=http://localhost:8080
-

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -50,7 +50,6 @@ func NewKubeHelper(kubeBase string, username string, password string, tokenPath 
 		if err != nil {
 			glog.Error("Unable to read token: %s\n", err)
 		}
-		glog.V(4).Infof("Token %s\n", token)
 		kubeHelper.auth = fmt.Sprintf("Bearer %s", string(token))
 	} else {
 		glog.V(4).Infof("Using basic auth\n")

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -35,7 +35,7 @@ type KubeHelper struct {
 	client   *http.Client
 }
 
-func NewKubeHelper(kubeBase string, username string, password string) (*KubeHelper, error) {
+func NewKubeHelper(kubeBase string, username string, password string, tokenPath string) (*KubeHelper, error) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
@@ -44,7 +44,6 @@ func NewKubeHelper(kubeBase string, username string, password string) (*KubeHelp
 	kubeHelper.kubeBase = kubeBase
 	kubeHelper.client = &http.Client{Transport: tr}
 
-	tokenPath := "/run/secrets/kubernetes.io/serviceaccount/token"
 	if _, err := os.Stat(tokenPath); err == nil {
 		glog.V(4).Infof("Reading token from %s\n", tokenPath)
 		token, err := ioutil.ReadFile(tokenPath)

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -15,6 +15,7 @@ import (
 	intstr "k8s.io/kubernetes/pkg/util/intstr"
 	utilrand "k8s.io/kubernetes/pkg/util/rand"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -29,9 +30,9 @@ type ServiceAddrPort struct {
 }
 
 type KubeHelper struct {
-	kubeBase  string
-	basicAuth string
-	client    *http.Client
+	kubeBase string
+	auth     string
+	client   *http.Client
 }
 
 func NewKubeHelper(kubeBase string, username string, password string) (*KubeHelper, error) {
@@ -39,12 +40,23 @@ func NewKubeHelper(kubeBase string, username string, password string) (*KubeHelp
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	auth := fmt.Sprintf("%s:%s", username, password)
+	kubeHelper := KubeHelper{}
+	kubeHelper.kubeBase = kubeBase
+	kubeHelper.client = &http.Client{Transport: tr}
 
-	kubeHelper := KubeHelper{
-		kubeBase:  kubeBase,
-		basicAuth: base64.StdEncoding.EncodeToString([]byte(auth)),
-		client:    &http.Client{Transport: tr},
+	tokenPath := "/run/secrets/kubernetes.io/serviceaccount/token"
+	if _, err := os.Stat(tokenPath); err == nil {
+		glog.V(4).Infof("Reading token from %s\n", tokenPath)
+		token, err := ioutil.ReadFile(tokenPath)
+		if err != nil {
+			glog.Error("Unable to read token: %s\n", err)
+		}
+		glog.V(4).Infof("Token %s\n", token)
+		kubeHelper.auth = fmt.Sprintf("Bearer %s", string(token))
+	} else {
+		glog.V(4).Infof("Using basic auth\n")
+		auth := fmt.Sprintf("%s:%s", username, password)
+		kubeHelper.auth = fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(auth)))
 	}
 
 	err := kubeHelper.isRunning()
@@ -57,7 +69,7 @@ func (k *KubeHelper) isRunning() error {
 	url := k.kubeBase + apiBase + "/"
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	_, httperr := k.client.Do(request)
 	if httperr != nil {
 		return httperr
@@ -80,7 +92,7 @@ func (k *KubeHelper) CreateNamespace(pid string) (*api.Namespace, error) {
 	glog.V(4).Infoln(url)
 	request, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -110,7 +122,7 @@ func (k *KubeHelper) GetNamespace(pid string) (*api.Namespace, error) {
 	glog.V(4).Infoln(url)
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -147,7 +159,7 @@ func (k *KubeHelper) DeleteNamespace(pid string) (*api.Namespace, error) {
 	glog.V(4).Infoln(url)
 	request, _ := http.NewRequest("DELETE", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -186,7 +198,7 @@ func (k *KubeHelper) StartController(pid string, spec *api.ReplicationController
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/replicationcontrollers"
 	request, _ := http.NewRequest("POST", url, bytes.NewBuffer([]byte(data)))
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -251,7 +263,7 @@ func (k *KubeHelper) StartService(pid string, spec *api.Service) (*api.Service, 
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/services"
 	request, _ := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -297,7 +309,7 @@ func (k *KubeHelper) GetService(pid string, name string) (*api.Service, error) {
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/services/" + name
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	resp, err := k.client.Do(request)
 	if err != nil {
 		glog.Error(err)
@@ -324,7 +336,7 @@ func (k *KubeHelper) GetServices(pid string, stack string) ([]api.Service, error
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/services?labelSelector=stack%3D" + stack
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	resp, err := k.client.Do(request)
 	if err != nil {
 		glog.Error(err)
@@ -354,7 +366,7 @@ func (k *KubeHelper) GetReplicationControllers(pid string, label string, value s
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/replicationcontrollers?labelSelector=" + label + "%3D" + value
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	resp, err := k.client.Do(request)
 	if err != nil {
 		glog.Error(err)
@@ -385,7 +397,7 @@ func (k *KubeHelper) GetPods(pid string, label string, value string) ([]api.Pod,
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/pods?labelSelector=" + label + "%3D" + value
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	resp, err := k.client.Do(request)
 	if err != nil {
 		glog.Error(err)
@@ -416,7 +428,7 @@ func (k *KubeHelper) StopService(pid string, name string) error {
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/services/" + name
 	request, _ := http.NewRequest("DELETE", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -438,7 +450,7 @@ func (k *KubeHelper) StopController(pid string, name string) error {
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/replicationcontrollers/" + name
 	request, _ := http.NewRequest("DELETE", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -502,7 +514,7 @@ func (k *KubeHelper) stopPod(pid string, podName string) error {
 	url := k.kubeBase + apiBase + "/namespaces/" + pid + "/pods/" + podName
 	request, _ := http.NewRequest("DELETE", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	httpresp, httperr := k.client.Do(request)
 	if httperr != nil {
 		glog.Error(httperr)
@@ -530,7 +542,7 @@ func (k *KubeHelper) GetLog(pid string, podName string, tailLines int) (string, 
 	glog.V(4).Infoln(url)
 	request, _ := http.NewRequest("GET", url, nil)
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	request.Header.Set("Authorization", k.auth)
 	resp, err := k.client.Do(request)
 	if err != nil {
 		glog.Error(err)

--- a/apiserver/server.go
+++ b/apiserver/server.go
@@ -50,9 +50,10 @@ type Config struct {
 		Address string
 	}
 	Kubernetes struct {
-		Address  string
-		Username string
-		Password string
+		Address   string
+		TokenPath string
+		Username  string
+		Password  string
 	}
 }
 
@@ -78,6 +79,9 @@ func main() {
 	if cfg.Kubernetes.Address == "" {
 		cfg.Kubernetes.Address = "localhost:6443"
 	}
+	if cfg.Kubernetes.TokenPath == "" {
+		cfg.Kubernetes.TokenPath = "/run/secrets/kubernetes.io/serviceaccount/token"
+	}
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -91,7 +95,7 @@ func main() {
 	}
 
 	kube, err := kube.NewKubeHelper(cfg.Kubernetes.Address,
-		cfg.Kubernetes.Username, cfg.Kubernetes.Password)
+		cfg.Kubernetes.Username, cfg.Kubernetes.Password, cfg.Kubernetes.TokenPath)
 	if err != nil {
 		glog.Errorf("Kubernetes API server not available\n")
 		glog.Fatal(err)

--- a/apiserver/version.go
+++ b/apiserver/version.go
@@ -1,5 +1,5 @@
 package main
 const (
   VERSION = "1.0-alpha"
-  BUILD_DATE = "2016-04-22 12:35"
+  BUILD_DATE = "2016-04-22 15:28"
 )

--- a/apiserver/version.go
+++ b/apiserver/version.go
@@ -1,5 +1,5 @@
 package main
 const (
   VERSION = "1.0-alpha"
-  BUILD_DATE = "2016-04-22 12:05"
+  BUILD_DATE = "2016-04-22 12:35"
 )


### PR DESCRIPTION
Updated kube/kube.go to read a token from a configured directory. 