### PR TITLE
NDS-181: Stop enforcing unique volume and stack names

### DIFF
--- a/apiserver/server.go
+++ b/apiserver/server.go
@@ -769,10 +769,6 @@ func (s *Server) PostStack(w rest.ResponseWriter, r *rest.Request) {
 	}
 
 	glog.V(4).Infof("Adding stack %s %s\n", stack.Key, stack.Name)
-	if s.stackExists(pid, stack.Name) {
-		w.WriteHeader(http.StatusConflict)
-		return
-	}
 
 	_, err = s.etcd.GetServiceSpec(stack.Key)
 	if err != nil {
@@ -1396,11 +1392,6 @@ func (s *Server) PostVolume(w rest.ResponseWriter, r *rest.Request) {
 	if err != nil {
 		glog.Error(err)
 		rest.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if s.volumeExists(pid, vol.Name) {
-		w.WriteHeader(http.StatusConflict)
 		return
 	}
 

--- a/apiserver/version.go
+++ b/apiserver/version.go
@@ -1,5 +1,5 @@
 package main
 const (
   VERSION = "1.0-alpha"
-  BUILD_DATE = "2016-04-22 12:05"
+  BUILD_DATE = "2016-04-25 08:54"
 )


### PR DESCRIPTION
Updated API server to no longer enforce unique stack and volume names, since IDs are unique.