### PR TITLE
Added no-cache headers for NDS-287

### DIFF
--- a/apiserver/middleware/no_cache.go
+++ b/apiserver/middleware/no_cache.go
@@ -1,0 +1,19 @@
+package rest
+
+import (
+	"github.com/ant0ine/go-json-rest/rest"
+)
+
+type NoCacheMiddleware struct{}
+
+func (mw *NoCacheMiddleware) MiddlewareFunc(handler rest.HandlerFunc) rest.HandlerFunc {
+
+	return func(w rest.ResponseWriter, r *rest.Request) {
+
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Pragma", "no-cache")
+		w.Header().Set("Expires", "0")
+
+		handler(w, r)
+	}
+}

--- a/apiserver/server.go
+++ b/apiserver/server.go
@@ -16,6 +16,7 @@ import (
 
 	etcd "github.com/ndslabs/apiserver/etcd"
 	kube "github.com/ndslabs/apiserver/kube"
+	mw "github.com/ndslabs/apiserver/middleware"
 	api "github.com/ndslabs/apiserver/types"
 	gcfg "gopkg.in/gcfg.v1"
 	k8api "k8s.io/kubernetes/pkg/api"
@@ -150,7 +151,8 @@ func (s *Server) start(cfg Config, adminPasswd string) {
 	os.MkdirAll(cfg.Server.VolDir, 0700)
 
 	api := rest.NewApi()
-	api.Use(rest.DefaultDevStack...)
+	api.Use(rest.DefaultProdStack...)
+	api.Use(&mw.NoCacheMiddleware{})
 
 	glog.Infof("prefix %s", s.prefix)
 


### PR DESCRIPTION
Added cache-control response headers to prevent IE from making our service look bad.