### PR TITLE
User home directory mounted on containers, AppData and GoDeps

### DIFF
--- a/apictl/Godeps/Godeps.json
+++ b/apictl/Godeps/Godeps.json
@@ -1,0 +1,126 @@
+{
+	"ImportPath": "github.com/ndslabs/apictl",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v65",
+	"Deps": [
+		{
+			"ImportPath": "github.com/BurntSushi/toml",
+			"Comment": "v0.1.0-25-g312db06",
+			"Rev": "312db06c6c6dbfa9899e58564bacfaa584f18ab7"
+		},
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.9.0-8-g57cce1e",
+			"Rev": "57cce1ed6103dce7791881d3e69e55f90d986aa5"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/term",
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/term/winconsole",
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/ast",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/parser",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/scanner",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/strconv",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/hcl/token",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/json/parser",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/json/scanner",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl/json/token",
+			"Rev": "1c284ec98f4b398443cbabb0d9197f7f4cc0077c"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+		},
+		{
+			"ImportPath": "github.com/kr/pretty",
+			"Comment": "go.weekly.2011-12-22-27-ge6ac2fc",
+			"Rev": "e6ac2fc51e89a3249e82157fa0bb7a18ef9dd5bb"
+		},
+		{
+			"ImportPath": "github.com/kr/text",
+			"Rev": "bb797dc4fb8320488f47bf11de07a733d7233e1f"
+		},
+		{
+			"ImportPath": "github.com/magiconair/properties",
+			"Comment": "v1.6.0-1-gc81f9d7",
+			"Rev": "c81f9d71af8f8cba1466501d30326b99a4e56c19"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/mapstructure",
+			"Rev": "740c764bc6149d3f1806231418adb9f52c11bcbf"
+		},
+		{
+			"ImportPath": "github.com/spf13/cast",
+			"Rev": "ee7b3e0353166ab1f3a605294ac8cd2b77953778"
+		},
+		{
+			"ImportPath": "github.com/spf13/cobra",
+			"Rev": "4c05eb1145f16d0e6bb4a3e1b6d769f4713cb41f"
+		},
+		{
+			"ImportPath": "github.com/spf13/jwalterweatherman",
+			"Rev": "d00654080cddbd2b082acaa74007cb94a2b40866"
+		},
+		{
+			"ImportPath": "github.com/spf13/pflag",
+			"Rev": "08b1a584251b5b62f458943640fc8ebd4d50aaa5"
+		},
+		{
+			"ImportPath": "github.com/spf13/viper",
+			"Rev": "c975dc1b4eacf4ec7fdbf0873638de5d090ba323"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ssh/terminal",
+			"Rev": "1f22c0103821b9390939b6776727195525381532"
+		},
+		{
+			"ImportPath": "golang.org/x/net/websocket",
+			"Rev": "c2528b2dd8352441850638a8bb678c2ad056fd3e"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e"
+		},
+		{
+			"ImportPath": "gopkg.in/fsnotify.v1",
+			"Comment": "v1.2.9",
+			"Rev": "8611c35ab31c1c28aa903d33cf8b6e44a399b09e"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "a83829b6f1293c91addabc89d0571c246397bbf4"
+		}
+	]
+}

--- a/apictl/Godeps/Readme
+++ b/apictl/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/apictl/gobuild.sh
+++ b/apictl/gobuild.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 cd /go/src/github.com/ndslabs/apictl
-go get
+go get github.com/tools/godep
+godep restore
 GOOS=linux GOARCH=amd64 go build -o build/bin/ndslabsctl-linux-amd64

--- a/apiserver/build.sh
+++ b/apiserver/build.sh
@@ -2,7 +2,7 @@
 
 BUILD_DATE=`date +%Y-%m-%d\ %H:%M`
 VERSIONFILE="version.go"
-VERSION="1.0-alpha"
+VERSION="1.0.1"
 APP="apiserver"
 
 if [ "$1" = "build" ] || [ -z $1 ]; then

--- a/apiserver/gobuild.sh
+++ b/apiserver/gobuild.sh
@@ -2,5 +2,6 @@
 
 cd /go/src/github.com/ndslabs/apiserver
 go get github.com/tools/godep
+godep restore
 #go build -ldflags "-X main.Version=0.1alpha -X main.BuildDate=`date "+%Y-%m-%dT%H:%M:%S"`"
 GOOS=linux GOARCH=amd64 godep go build -o build/bin/apiserver-linux-amd64

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -797,6 +797,10 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 	}
 
 	k8volMounts := []api.VolumeMount{}
+	// Mount the home directory
+	k8homeVol := api.VolumeMount{Name: "home", MountPath: "/home/" + ns}
+	k8volMounts = append(k8volMounts, k8homeVol)
+
 	if len(spec.VolumeMounts) > 0 {
 		for _, vol := range spec.VolumeMounts {
 			k8vol := api.VolumeMount{Name: vol.Name, MountPath: vol.MountPath}

--- a/apiserver/server.go
+++ b/apiserver/server.go
@@ -1647,7 +1647,6 @@ func (s *Server) PostVolume(w rest.ResponseWriter, r *rest.Request) {
 		vol.Status = "available"
 	}
 
-	glog.V(4).Infoln("Creating local volume")
 	uid, err := newUUID()
 	if err != nil {
 		glog.Error(err)
@@ -1656,6 +1655,7 @@ func (s *Server) PostVolume(w rest.ResponseWriter, r *rest.Request) {
 	}
 	vol.Id = uid
 
+	glog.V(4).Infof("Creating local volume %s", s.volDir+"/"+pid+"/AppData/"+uid)
 	err = os.MkdirAll(s.volDir+"/"+pid+"/AppData/"+uid, 0755)
 	if err != nil {
 		glog.Error(err)
@@ -1764,6 +1764,7 @@ func (s *Server) DeleteVolume(w rest.ResponseWriter, r *rest.Request) {
 
 	glog.V(4).Infof("Format %s\n", volume.Format)
 	if volume.Format == "hostPath" {
+		glog.V(4).Infof("Removing volume %s\n", s.volDir+"/"+pid+"/AppData/"+volume.Id)
 		err = os.RemoveAll(s.volDir + "/" + pid + "/AppData/" + volume.Id)
 		if err != nil {
 			rest.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
This PR covers the following changes:
* NDS-354: Added GoDeps support to apiserver and apictl to resolve build errors
* NDS-350: Mount home directory on /home/<ns> for every running container.
* NDS-334: Moved stack data to an "AppData" subdirectory of user's home directory