### PR TITLE
Added support for simple vocabulary for tags

### DIFF
--- a/apictl/client/client.go
+++ b/apictl/client/client.go
@@ -893,3 +893,32 @@ func (c *Client) CheckConsole(ssid string) error {
 		}
 	}
 }
+
+func (c *Client) GetVocabulary(name string) (*api.Vocabulary, error) {
+
+	url := c.BasePath + "vocabulary/" + name
+
+	request, err := http.NewRequest("GET", url, nil)
+
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	resp, err := c.HttpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusOK {
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		vocab := api.Vocabulary{}
+		json.Unmarshal([]byte(body), &vocab)
+		return &vocab, nil
+	} else {
+		err := errors.New(resp.Status)
+		return nil, err
+	}
+}

--- a/apictl/cmd/get.go
+++ b/apictl/cmd/get.go
@@ -143,9 +143,32 @@ var getAccountCmd = &cobra.Command{
 	PostRun: RefreshToken,
 }
 
+var getTagsCmd = &cobra.Command{
+	Use:    "tags",
+	Short:  "Get tags",
+	PreRun: Connect,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		vocab, err := client.GetVocabulary("tags")
+		if err != nil {
+			fmt.Printf("Get vocabulary failed: %s\n", err)
+			return
+		}
+
+		data, err := json.MarshalIndent(vocab, "", "   ")
+		if err != nil {
+			fmt.Printf("Error marshalling vocab spec %s\n", err.Error)
+			return
+		}
+		fmt.Println(string(data))
+	},
+	PostRun: RefreshToken,
+}
+
 func init() {
 	RootCmd.AddCommand(getCmd)
 	getCmd.AddCommand(getServiceCmd)
 	getCmd.AddCommand(getStackCmd)
 	getCmd.AddCommand(getAccountCmd)
+	getCmd.AddCommand(getTagsCmd)
 }

--- a/apiserver/etcd/etcd.go
+++ b/apiserver/etcd/etcd.go
@@ -395,3 +395,32 @@ func (s *EtcdHelper) GetStacks(uid string) (*[]api.Stack, error) {
 	}
 	return &stacks, nil
 }
+
+func (s *EtcdHelper) PutVocabulary(name string, vocabulary *api.Vocabulary) error {
+	data, err := json.Marshal(vocabulary)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+	_, err = s.etcd.Set(context.Background(), etcdBasePath+"/vocabularies/"+name, string(data), nil)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+	return nil
+}
+
+func (s *EtcdHelper) GetVocabulary(name string) (*api.Vocabulary, error) {
+	resp, err := s.etcd.Get(context.Background(), etcdBasePath+"/vocabularies/"+name, nil)
+	if err != nil {
+		if !client.IsKeyNotFound(err) {
+			glog.Error(err)
+			return nil, err
+		}
+	} else {
+		vocab := api.Vocabulary{}
+		json.Unmarshal([]byte(resp.Node.Value), &vocab)
+		return &vocab, nil
+	}
+	return nil, nil
+}

--- a/apiserver/server.go
+++ b/apiserver/server.go
@@ -305,6 +305,7 @@ func (s *Server) start(cfg Config, adminPasswd string) {
 		rest.Get(s.prefix+"logs/:ssid", s.GetLogs),
 		rest.Get(s.prefix+"console", s.GetConsole),
 		rest.Get(s.prefix+"check_console", s.CheckConsole),
+		rest.Get(s.prefix+"vocabulary/:name", s.GetVocabulary),
 	)
 
 	router, err := rest.MakeRouter(routes...)
@@ -320,6 +321,7 @@ func (s *Server) start(cfg Config, adminPasswd string) {
 		if err != nil {
 			glog.Warningf("Error loading specs: %s\n", err)
 		}
+		s.addVocabulary(cfg.Server.SpecsDir + "/vocab/tags.json")
 	}
 
 	go s.initExistingAccounts()
@@ -2025,13 +2027,14 @@ func (s *Server) loadSpecs(path string) error {
 
 	for _, file := range files {
 		if file.IsDir() {
-			if file.Name() != "test" {
+			if file.Name() != "vocab" {
 				s.loadSpecs(fmt.Sprintf("%s/%s", path, file.Name()))
 			}
 		} else {
 			s.addServiceFile(fmt.Sprintf("%s/%s", path, file.Name()))
 		}
 	}
+
 	return nil
 }
 
@@ -2171,4 +2174,35 @@ func (s *Server) detachVolume(userId string, ssid string) bool {
 		}
 	}
 	return false
+}
+
+func (s *Server) addVocabulary(path string) error {
+	if path[len(path)-4:len(path)] != "json" {
+		return nil
+	}
+	glog.V(4).Infof("Adding vocabulary %s", path)
+	vocab := api.Vocabulary{}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	err = json.Unmarshal(data, &vocab)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	s.etcd.PutVocabulary(vocab.Name, &vocab)
+	return nil
+}
+
+func (s *Server) GetVocabulary(w rest.ResponseWriter, r *rest.Request) {
+	name := r.PathParam("name")
+	vocab, err := s.etcd.GetVocabulary(name)
+	if err != nil {
+		rest.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else {
+		w.WriteJson(&vocab)
+	}
 }

--- a/apiserver/types/types.go
+++ b/apiserver/types/types.go
@@ -162,3 +162,14 @@ type Volume struct {
 	CreatedTime int    `json:"createdTime"`
 	UpdatedTime int    `json:"updateTime"`
 }
+
+type Vocabulary struct {
+	Name  string `json:"name"`
+	Terms []Term `json:"terms"`
+}
+
+type Term struct {
+	Id         string `json:"id"`
+	Name       string `json:"name"`
+	Definition string `json:"definition"`
+}


### PR DESCRIPTION
* Add new GetVocabulary method to API server 
* Vocabularies are loaded from "vocab" subdirectory of ndslabs-specs repository.  Currently, there is a single "tags.json" vocabulary.
