### PR TITLE
NDS 384: Services are created/deleted during add/remove stack

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -3,10 +3,10 @@ MAINTAINER willis8@illinois.edu
 
 COPY . /go/src/github.com/ndslabs/apiserver
 
-RUN apt-get update -y && \
-	apt-get install -y curl gcc git vim && \
+RUN apt-get update -y -qq && \
+	apt-get install -y -qq curl gcc git vim && \
     mkdir /golang && cd /golang && \
-	curl -O curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz && \
+	curl -s -O curl -O https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz && \
 	tar -xvf go1.6.linux-amd64.tar.gz && \
     export GOROOT=/golang/go && \
     export GOPATH=/go/ && \
@@ -17,8 +17,8 @@ RUN apt-get update -y && \
     mv build/bin/apiserver-linux-amd64 /apiserver && \
     rm -rf /golang && \
     rm -rf /go && \
-    apt-get remove --purge gcc -y && \
-    apt-get autoremove -y
+    apt-get remove --purge gcc -y -qq && \
+    apt-get autoremove -y -qq
     
 
 #COPY build/bin/apiserver-linux-amd64 /apiserver

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -696,7 +696,8 @@ func (k *KubeHelper) RandomString(randomLength int) string {
 	return utilrand.String(randomLength)
 }
 
-func (k *KubeHelper) CreateServiceTemplate(name string, stack string, spec *ndsapi.ServiceSpec) *api.Service {
+func (k *KubeHelper) CreateServiceTemplate(name string, stack string, spec *ndsapi.ServiceSpec,
+	useNodePort bool) *api.Service {
 
 	// Create the Kubernetes service definition
 	k8svc := api.Service{
@@ -719,7 +720,7 @@ func (k *KubeHelper) CreateServiceTemplate(name string, stack string, spec *ndsa
 		},
 	}
 
-	if spec.Access == ndsapi.AccessExternal {
+	if useNodePort && spec.Access == ndsapi.AccessExternal {
 		k8svc.Spec.Type = api.ServiceTypeNodePort
 	}
 

--- a/apiserver/server.go
+++ b/apiserver/server.go
@@ -2042,10 +2042,10 @@ func (s *Server) GetVocabulary(w rest.ResponseWriter, r *rest.Request) {
 	}
 }
 
-func (s *Server) useNodePort() {
+func (s *Server) useNodePort() bool {
 	return s.ingress == IngressTypeNodePort
 }
 
-func (s *Server) useLoadBalancer() {
+func (s *Server) useLoadBalancer() bool {
 	return s.ingress == IngressTypeLoadBalancer
 }


### PR DESCRIPTION
* Kubernetes services are now created/deleted during PostStack/DeleteStack operations. This means that the IP address and NodePort remains the same across restarts.
* No longer create NodePorts if API server is configured to use the loadbalancer