### PR TITLE
NDS 536: Default timeout and "Failed Sync" errors

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1803,8 +1803,8 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 	}
 	timeWait := time.Second * 0
 	for (ready + failed) < len(stack.Services) {
-		stack2, _ := s.etcd.GetStack(userId, stack.Id)
-		for _, ss := range stack2.Services {
+		stck, _ := s.etcd.GetStack(userId, stack.Id)
+		for _, ss := range stck.Services {
 			glog.V(4).Infof("Stack service %s: status=%s\n", ss.Id, ss.Status)
 			if ss.Status == "ready" {
 				ready++
@@ -1873,7 +1873,6 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 
 	sid := stack.Id
 	stack.Status = stackStatus[Starting]
-	glog.V(4).Infoln("PutStack (startStack)")
 	s.etcd.PutStack(userId, sid, stack)
 
 	stackServices := stack.Services
@@ -2060,7 +2059,6 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 	}
 
 	stack.Status = stackStatus[Stopping]
-	glog.V(4).Infoln("PutStack (stopStack start)")
 	s.etcd.PutStack(userId, sid, stack)
 
 	// For each stack service, stop dependent services first.
@@ -2118,7 +2116,6 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 		stackService.Endpoints = nil
 	}
 
-	glog.V(4).Infoln("PutStack (stopStack end)")
 	stack.Status = stackStatus[Stopped]
 	s.etcd.PutStack(userId, sid, stack)
 
@@ -2340,7 +2337,6 @@ func (s *Server) HandlePodEvent(eventType watch.EventType, event *k8api.Event, p
 			glog.V(4).Infof("Namespace: %s, Pod: %s, Status: %s, StatusMessage: %s\n", userId, pod.Name,
 				stackService.Status, message)
 
-			glog.V(4).Infoln("PutStack (HandlePodEvent)")
 			s.etcd.PutStack(userId, sid, stack)
 		}
 	}
@@ -2382,7 +2378,6 @@ func (s *Server) HandleReplicationControllerEvent(eventType watch.EventType, eve
 			glog.V(4).Infof("Namespace: %s, ReplicationController: %s, Status: %s, StatusMessage: %s\n", userId, rc.Name,
 				stackService.Status, stackService.StatusMessages[len(stackService.StatusMessages)-1])
 		}
-		glog.V(4).Infoln("PutStack (HandleRCEvent)")
 		s.etcd.PutStack(userId, sid, stack)
 	}
 }

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -2074,10 +2074,6 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 			}
 
 			glog.V(4).Infof("Stopping service %s\n", stackService.Service)
-			stackService.StatusMessages = append(stackService.StatusMessages,
-				fmt.Sprintf("Stopping service\n"))
-			stackService.Status = "stopping"
-			s.etcd.PutStack(userId, stack.Id, stack)
 
 			numDeps := 0
 			stoppedDeps := 0

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1799,7 +1799,7 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 
 	timeOut := defaultTimeout
 	if spec.ReadyProbe.Timeout > 0 {
-		timeOut = spec.ReadyProbe.Timeout
+		timeOut = int(spec.ReadyProbe.Timeout)
 	}
 	timeWait := time.Second * 0
 	for (ready + failed) < len(stack.Services) {

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -2073,7 +2073,12 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 				continue
 			}
 
-			glog.V(4).Infof("Stopping stack service %s\n", stackService.Service)
+			glog.V(4).Infof("Stopping service %s\n", stackService.Service)
+			stackService.StatusMessages = append(stackService.StatusMessages,
+				fmt.Sprintf("Stopping service\n"))
+			stackService.Status = "stopping"
+			s.etcd.PutStack(userId, stack.Id, stack)
+
 			numDeps := 0
 			stoppedDeps := 0
 			for _, ss := range stack.Services {

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1823,15 +1823,16 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 			stackService.StatusMessages = append(stackService.StatusMessages,
 				fmt.Sprintf("Service timed out after %d seconds\n", timeOut))
 			stackService.Status = "timeout"
+
+			// Update stack status
+			s.etcd.PutStack(userId, stack.Id, stack)
+
 			failed++
 			break
 		}
 		time.Sleep(time.Second * 3)
 		timeWait += time.Second * 3
 	}
-
-	// Update stack status
-	s.etcd.PutStack(userId, stack.Id, stack)
 
 	if failed > 0 {
 		return false, nil

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1871,6 +1871,7 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 
 	sid := stack.Id
 	stack.Status = stackStatus[Starting]
+	glog.V(4).Infoln("PutStack (startStack)")
 	s.etcd.PutStack(userId, sid, stack)
 
 	stackServices := stack.Services
@@ -1958,8 +1959,8 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 		}
 	}
 
-	s.etcd.PutStack(userId, sid, stack)
 	glog.V(4).Infof("Stack %s started\n", sid)
+	s.etcd.PutStack(userId, sid, stack)
 
 	return stack, nil
 }
@@ -2057,6 +2058,7 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 	}
 
 	stack.Status = stackStatus[Stopping]
+	glog.V(4).Infoln("PutStack (stopStack start)")
 	s.etcd.PutStack(userId, sid, stack)
 
 	// For each stack service, stop dependent services first.
@@ -2114,6 +2116,7 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 		stackService.Endpoints = nil
 	}
 
+	glog.V(4).Infoln("PutStack (stopStack end)")
 	stack.Status = stackStatus[Stopped]
 	s.etcd.PutStack(userId, sid, stack)
 
@@ -2332,6 +2335,8 @@ func (s *Server) HandlePodEvent(eventType watch.EventType, event *k8api.Event, p
 			}
 			glog.V(4).Infof("Namespace: %s, Pod: %s, Status: %s, StatusMessage: %s\n", userId, pod.Name,
 				stackService.Status, message)
+
+			glog.V(4).Infoln("PutStack (HandlePodEvent)")
 			s.etcd.PutStack(userId, sid, stack)
 		}
 	}
@@ -2373,6 +2378,7 @@ func (s *Server) HandleReplicationControllerEvent(eventType watch.EventType, eve
 			glog.V(4).Infof("Namespace: %s, ReplicationController: %s, Status: %s, StatusMessage: %s\n", userId, rc.Name,
 				stackService.Status, stackService.StatusMessages[len(stackService.StatusMessages)-1])
 		}
+		glog.V(4).Infoln("PutStack (HandleRCEvent)")
 		s.etcd.PutStack(userId, sid, stack)
 	}
 }

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -95,6 +95,8 @@ const (
 	IngressTypeNodePort     IngressType = "NodePort"
 )
 
+var defaultTimeout = 600
+
 func main() {
 
 	var confPath, adminPasswd string
@@ -1795,6 +1797,10 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 	ready := 0
 	failed := 0
 
+	timeOut := defaultTimeout
+	if spec.ReadyProbe.Timeout > 0 {
+		timeOut = spec.ReadyProbe.Timeout
+	}
 	timeWait := time.Second * 0
 	for (ready + failed) < len(stack.Services) {
 		stack, _ := s.etcd.GetStack(userId, stack.Id)

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1814,18 +1814,19 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 		}
 
 		if timeWait > time.Duration(timeOut)*time.Second {
-			// Service has taken too long to startup
-			glog.V(4).Infof("Stack service %s reached timeout, stopping\n", stackService.Id)
-			err := s.kube.StopController(userId, stackService.Id)
-			if err != nil {
-				glog.Error(err)
-			}
 			stackService.StatusMessages = append(stackService.StatusMessages,
 				fmt.Sprintf("Service timed out after %d seconds\n", timeOut))
 			stackService.Status = "timeout"
 
 			// Update stack status
 			s.etcd.PutStack(userId, stack.Id, stack)
+
+			// Service has taken too long to startup
+			glog.V(4).Infof("Stack service %s reached timeout, stopping\n", stackService.Id)
+			err := s.kube.StopController(userId, stackService.Id)
+			if err != nil {
+				glog.Error(err)
+			}
 
 			failed++
 			break

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1813,7 +1813,7 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 			}
 		}
 
-		if timeWait > time.Duration(spec.ReadyProbe.Timeout)*time.Second {
+		if timeWait > time.Duration(timeOut)*time.Second {
 			// Service has taken too long to startup
 			glog.V(4).Infof("Stack service %s reached timeout, stopping\n", stackService.Id)
 			err := s.kube.StopController(userId, stackService.Id)
@@ -1821,7 +1821,7 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 				glog.Error(err)
 			}
 			stackService.StatusMessages = append(stackService.StatusMessages,
-				fmt.Sprintf("Service timed out after %d seconds\n", spec.ReadyProbe.Timeout))
+				fmt.Sprintf("Service timed out after %d seconds\n", timeOut))
 			stackService.Status = "timeout"
 			failed++
 			break


### PR DESCRIPTION
* Set system default timeout to 600 seconds when no readiness probe specified.
* Kubernetes FailedSync and Backoff warnings are now reported as errors