### PR TITLE
NDS-577/584/552: Healthz and bug fixes

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -221,7 +221,8 @@ func (s *Server) start(cfg Config, adminPasswd string) {
 		api.Use(&rest.CorsMiddleware{
 			RejectNonCorsRequests: false,
 			OriginValidator: func(origin string, request *rest.Request) bool {
-				return origin == cfg.Server.Origin
+				// NDS-552
+				return origin == cfg.Server.Origin || origin == cfg.Server.Origin+"."
 			},
 			AllowedMethods: []string{"GET", "POST", "PUT", "DELETE"},
 			AllowedHeaders: []string{

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -450,6 +450,7 @@ func (s *Server) GetPaths(w rest.ResponseWriter, r *rest.Request) {
 	paths = append(paths, s.prefix+"configs")
 	paths = append(paths, s.prefix+"console")
 	paths = append(paths, s.prefix+"contact")
+	paths = append(paths, s.prefix+"healthz")
 	paths = append(paths, s.prefix+"logs")
 	paths = append(paths, s.prefix+"register")
 	paths = append(paths, s.prefix+"reset")
@@ -2738,7 +2739,7 @@ func (s *Server) GetHealthz(w rest.ResponseWriter, r *rest.Request) {
 	}
 
 	// Confirm access to Kubernetes API
-	_, err = s.kube.GetSecret(adminUser, "ndslabs-tls-secret")
+	_, err = s.kube.GetSecret("default", "ndslabs-tls-secret")
 	if err != nil {
 		rest.Error(w, "Kubernetes API not available", http.StatusInternalServerError)
 		return

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -2549,12 +2549,13 @@ func (s *Server) ResetPassword(w rest.ResponseWriter, r *rest.Request) {
 	token, err := s.getTemporaryToken(userId)
 	if err != nil {
 		glog.Error(err)
-		rest.Error(w, err.Error(), http.StatusInternalServerError)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 	account, err := s.etcd.GetAccount(userId)
 	if err != nil {
-		rest.NotFound(w, r)
+		glog.Error(err)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
@@ -2568,7 +2569,7 @@ func (s *Server) ResetPassword(w rest.ResponseWriter, r *rest.Request) {
 
 	if err != nil {
 		glog.Error(err)
-		rest.Error(w, err.Error(), http.StatusInternalServerError)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -2740,7 +2740,7 @@ func (s *Server) GetHealthz(w rest.ResponseWriter, r *rest.Request) {
 	}
 
 	// Confirm access to Kubernetes API
-	_, err = s.kube.GetSecret("default", "ndslabs-tls-secret")
+	_, err = s.kube.GetNamespace(adminUser)
 	if err != nil {
 		rest.Error(w, "Kubernetes API not available", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
* NDS-577: Added /healthz endpoint that checks etcd, kubernetes API, and gluster availability
* NDS-584: Forgot password for invalid user returns 404
* NDS-552: Added CORS host for <host>.