### PR TITLE
NDS-601: setTo config support

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update -y -qq && \
     apt-get autoremove -y -qq
     
 
-COPY entrypoint.sh /
-COPY templates /templates
+COPY ./entrypoint.sh /
+COPY ./templates /templates
 
 VOLUME /volumes
 

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1546,7 +1546,7 @@ func (s *Server) createIngressRule(userId string, svc *k8api.Service, stack *api
 		glog.Error(err)
 		return err
 	}
-	glog.V(4).Infof("Started ingress %s for service %s\n", host, svc.Name)
+	glog.V(4).Infof("Started ingress %s for service %s (secure=%t)\n", host, svc.Name, stack.Secure)
 	return nil
 }
 

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1763,9 +1763,10 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 		if len(config.UseFrom) > 0 {
 			for i := range stack.Services {
 				ss := &stack.Services[i]
-				if config.UseFrom == ss.Service {
+				useFrom := strings.Split(config.UseFrom, ".")
+				if useFrom[0] == ss.Service {
 					glog.V(4).Infof("Setting %s %s to %s %s\n", stackService.Id, config.Name, ss.Id, ss.Config[config.Name])
-					stackService.Config[config.Name] = ss.Config[config.Name]
+					stackService.Config[config.Name] = ss.Config[useFrom[1]]
 				}
 
 			}
@@ -2699,8 +2700,9 @@ func (s *Server) checkDependencies(uid string, service *api.ServiceSpec) (string
 func (s *Server) checkConfigs(uid string, service *api.ServiceSpec) (string, bool) {
 	for _, config := range service.Config {
 		if len(config.UseFrom) > 0 {
-			if !s.serviceExists(uid, config.UseFrom) {
-				return config.UseFrom, false
+			useFrom := strings.Split(config.UseFrom, ".")
+			if !s.serviceExists(uid, useFrom[0]) {
+				return useFrom[0], false
 			}
 		}
 	}

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -1198,7 +1198,12 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 				},
 			},
 		}
+	} else {
+		if !basicAuth {
+			ingress.Annotations = map[string]string{}
+		}
 	}
+
 	return k.CreateUpdateIngress(pid, ingress, update)
 }
 

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -1151,9 +1151,6 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 	update := true
 
 	ingress, err := k.GetIngress(pid, name)
-	if err != nil {
-		return nil, err
-	}
 	if ingress == nil {
 		update = false
 

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -1151,7 +1151,7 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 	update := true
 
 	ingress, err := k.GetIngress(pid, name)
-	if err == nil {
+	if err != nil {
 		return nil, err
 	}
 	if ingress == nil {

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -1157,19 +1157,10 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 	if ingress == nil {
 		update = false
 
-		// https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/auth
-		annotations := map[string]string{}
-		if basicAuth {
-			annotations["ingress.kubernetes.io/auth-type"] = "basic"
-			annotations["ingress.kubernetes.io/auth-secret"] = "basic-auth"
-			annotations["ingress.kubernetes.io/auth-realm"] = "NDS Labs"
-		}
-
 		ingress = &extensions.Ingress{
 			ObjectMeta: api.ObjectMeta{
-				Name:        name,
-				Namespace:   pid,
-				Annotations: annotations,
+				Name:      name,
+				Namespace: pid,
 			},
 			Spec: extensions.IngressSpec{
 				TLS: []extensions.IngressTLS{
@@ -1198,12 +1189,18 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 				},
 			},
 		}
-	} else {
-		if !basicAuth {
-			glog.V(4).Info("Removing basic-auth annotations for " + ingress.Name)
-			ingress.Annotations = map[string]string{}
-		}
 	}
+
+	annotations := map[string]string{}
+	if !basicAuth {
+		glog.V(4).Info("Removing basic-auth annotations for " + ingress.Name)
+	}
+	if basicAuth {
+		annotations["ingress.kubernetes.io/auth-type"] = "basic"
+		annotations["ingress.kubernetes.io/auth-secret"] = "basic-auth"
+		annotations["ingress.kubernetes.io/auth-realm"] = "NDS Labs"
+	}
+	ingress.Annotations = annotations
 
 	return k.CreateUpdateIngress(pid, ingress, update)
 }

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -829,8 +829,8 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 			api.ResourceMemory: resource.MustParse(fmt.Sprintf("%dM", spec.ResourceLimits.MemoryMax)),
 		}
 		k8rq.Requests = api.ResourceList{
-			api.ResourceCPU:    resource.MustParse(fmt.Sprintf("%dm", spec.ResourceLimits.CPUMax)),
-			api.ResourceMemory: resource.MustParse(fmt.Sprintf("%dM", spec.ResourceLimits.MemoryMax)),
+			api.ResourceCPU:    resource.MustParse(fmt.Sprintf("%dm", spec.ResourceLimits.CPUDefault)),
+			api.ResourceMemory: resource.MustParse(fmt.Sprintf("%dM", spec.ResourceLimits.MemoryDefault)),
 		}
 	} else {
 		glog.Warningf("No resource requirements specified for service %s\n", spec.Label)

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -1150,7 +1150,7 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 	name := service + "-ingress"
 	update := true
 
-	ingress, err := k.GetIngress(pid, name)
+	ingress, _ := k.GetIngress(pid, name)
 	if ingress == nil {
 		update = false
 

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -1200,6 +1200,7 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 		}
 	} else {
 		if !basicAuth {
+			glog.V(4).Info("Removing basic-auth annotations for " + ingress.Name)
 			ingress.Annotations = map[string]string{}
 		}
 	}
@@ -1209,6 +1210,7 @@ func (k *KubeHelper) CreateIngress(pid string, host string, service string, port
 
 func (k *KubeHelper) CreateUpdateIngress(pid string, ingress *extensions.Ingress, update bool) (*extensions.Ingress, error) {
 
+	glog.V(4).Info("Updating ingress " + ingress.Name)
 	ingress.ObjectMeta.Annotations["ndslabs.org/updated"] = time.Now().String()
 	data, err := json.Marshal(ingress)
 	if err != nil {

--- a/apiserver/pkg/types/types.go
+++ b/apiserver/pkg/types/types.go
@@ -68,6 +68,7 @@ type Config struct {
 	IsPassword  bool   `json:"isPassword"`
 	CanOverride bool   `json:"canOverride"`
 	UseFrom     string `json:"useFrom"`
+	SetTo       string `json:"setTo"`
 }
 
 type Port struct {


### PR DESCRIPTION
* Added support for config.setTo
* Changed config.useFrom to use key.ENV_VAR format
* Fixed bug with creation of Kubernetes resource limits where requests were using max cpu/memory instead of default cpu/memory.
* NDS-631: Delete basic auth annotations from ingress when secure=false