### PR TITLE
NDS-619: Admin user didn't have default storage quota

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -2613,6 +2613,7 @@ func (s *Server) createAdminUser(password string) error {
 				CPUDefault:    s.cpuDefault,
 				MemoryMax:     s.memMax,
 				MemoryDefault: s.memDefault,
+				StorageQuota:  s.storageDefault,
 			},
 		}
 		err := s.etcd.PutAccount(adminUser, account, true)


### PR DESCRIPTION
* Added default storage quota during admin user creation