### PR TITLE
NDS-651 Fixed error when updating non-existing ingress rule 

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1623,11 +1623,13 @@ func (s *Server) PutStack(w rest.ResponseWriter, r *rest.Request) {
 			spec, _ := s.etcd.GetServiceSpec(userId, stackService.Service)
 			name := fmt.Sprintf("%s-%s", newStack.Id, spec.Key)
 			svc, _ := s.kube.GetService(userId, name)
-			err := s.createIngressRule(userId, svc, &newStack)
-			if err != nil {
-				glog.Error(err)
-				rest.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+			if s.useLoadBalancer() && spec.Access == api.AccessExternal {
+				err := s.createIngressRule(userId, svc, &newStack)
+				if err != nil {
+					glog.Error(err)
+					rest.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
 			}
 		}
 

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -978,7 +978,8 @@ func (k *KubeHelper) WatchPods(handler events.EventHandler) {
 				for {
 					data, err := reader.ReadBytes('\n')
 					if err != nil {
-						glog.Error(err)
+						// TODO: NDS-372
+						//glog.Error(err)
 						break
 					}
 


### PR DESCRIPTION
* Ingress rules don't exist for services with access=internal.
* Added check during update of secure flag to not try to update ingress rule
* NDS-372: Removed EOF error logging for now