### PR TITLE
NDS-623: Many specs with HTTP ports are missing context paths

### DIFF
--- a/gui/app/catalog/addOrEdit/AddOrEditSpecController.js
+++ b/gui/app/catalog/addOrEdit/AddOrEditSpecController.js
@@ -187,12 +187,15 @@ angular
   $scope.save = function(display) {
     var spec = angular.copy($scope.spec);
     spec.display = 'stack';
+    
+    // Explode command into array
     if (!$scope.spec.command || $scope.spec.command.replace(/ /g,'') === '') {
       spec.command = null;
     } else {
       spec.command = _.split($scope.spec.command, ' ');
     }
     
+    // Explode args into array
     if (!$scope.spec.args || $scope.spec.args.replace(/ /g,'') === '') {
       spec.args = null;
     } else {
@@ -205,6 +208,13 @@ angular
     } else {
       spec.readinessProbe = angular.copy($scope.probe);
     }
+    
+    // Replace a value of "" in contextPath with "/"
+    angular.forEach($scope.spec.ports, function(port) {
+      if (!port.contextPath || port.contextPath.replace(/ /g,'') === '') {
+        port.contextPath = '/';
+      }
+    });
     
     var method = $scope.editingSpec ? 'putServicesByServiceId' : 'postServices';
     return NdsLabsApi[method]({ service: spec, serviceId: spec.key }).then(function(data) {

--- a/gui/app/catalog/addOrEdit/addOrEditSpec.html
+++ b/gui/app/catalog/addOrEdit/addOrEditSpec.html
@@ -581,7 +581,7 @@
                                                     </ng-messages>
                                                   </div>
                                                 </td>
-                                                <td><button id="addPortBtn" class="btn btn-xs btn-primary" ng-click="spec.ports.push({ protocol: portProtocol, port: portNumber, contextPath: portPath });portNumber=1;portPath='/';" 
+                                                <td><button id="addPortBtn" class="btn btn-xs btn-primary" ng-click="spec.ports.push({ protocol: portProtocol, port: portNumber, contextPath: portPath || '/' });portNumber=1;portPath='/';" 
                                                     ng-disabled="!portNumber || (portProtocol === 'http' && modifySpec['portPathField'].$invalid) || _.find(spec.ports, { protocol:portProtocol, port:portNumber })" ><i class="fa fa-fw fa-plus"></i></button></td>
                                               </tr>
                                           </table>


### PR DESCRIPTION
Change the UI to replace a value of "" in contextPath with "/"

See https://opensource.ncsa.illinois.edu/jira/browse/NDS-623