### PR TITLE
Fix "Missing local grunt" error on master

### DIFF
--- a/gui/install-headless-deps.sh
+++ b/gui/install-headless-deps.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install karma and friends
+npm install --only=dev
+
 # Add Firefox debian repo and key
 echo 'Installing E2E dependencies...'
 echo 'deb http://mozilla.debian.net/ jessie-backports firefox-release' > /etc/apt/sources.list.d/debian-mozilla.list && \

--- a/gui/package.json
+++ b/gui/package.json
@@ -6,6 +6,19 @@
   "repository": "https://github.com/nds-org/ndslabs",
   "license": "MIT",
   "devDependencies": {
+    "jasmine-core": "^2.5.2",
+    "karma": "^1.3.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-coverage": "^1.1.1",
+    "karma-htmlfile-reporter": "^0.3.4",
+    "karma-jasmine": "^1.0.2",
+    "swagger-js-codegen": "^1.6.9",
+    "yamljs": "^0.2.8"
+  },
+  "dependencies": {
+    "body-parser": "^1.15.2",
+    "bower": "^1.7.7",
+    "express": "^4.14.0",
     "grunt": "^0.4.5",
     "grunt-auto-install": "^0.3.1",
     "grunt-contrib-csslint": "^2.0.0",
@@ -19,23 +32,9 @@
     "grunt-protractor-runner": "^4.0.0",
     "grunt-shell-spawn": "^0.3.10",
     "grunt-wait": "^0.1.0",
-    "jasmine-core": "^2.5.2",
-    "karma": "^1.3.0",
-    "karma-chrome-launcher": "^2.0.0",
-    "karma-coverage": "^1.1.1",
-    "karma-htmlfile-reporter": "^0.3.4",
-    "karma-jasmine": "^1.0.2",
     "load-grunt-tasks": "^3.5.2",
-    "swagger-js-codegen": "^1.6.9",
-    "time-grunt": "^1.4.0",
-    "watchify": "^3.7.0",
-    "yamljs": "^0.2.8"
-  },
-  "dependencies": {
-    "body-parser": "^1.15.2",
-    "bower": "^1.7.7",
-    "express": "^4.14.0",
-    "morgan": "^1.7.0"
+    "morgan": "^1.7.0",
+    "time-grunt": "^1.4.0"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
* Move `grunt` and friends from devDependencies to dependencies (so they are installed even when NODE_ENV == production)
* Add `npm install --only=dev` to the install-headless-deps script