### PR TITLE
NDS-1116: Adds oauth endpoint to apiserver

### DIFF
--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -96,6 +96,14 @@ if [ "$1" = 'apiserver' ]; then
 		TOKEN_PATH="/run/secrets/kubernetes.io/serviceaccount/token"
 	fi
 
+	if [ -z "$SIGNIN_URL" ]; then 
+    		SIGNIN_URL="$CORS_ORIGIN_ADDR/login/#/",
+	fi
+        
+	if [ -z "$AUTH_URL" ]; then 
+    		AUTH_URL="$CORS_ORIGIN_ADDR/cauth/auth"
+	fi
+
 cat << EOF > /apiserver.json
 {
     "port": "30001",
@@ -111,8 +119,8 @@ cat << EOF > /apiserver.json
     "homeVolume": "$VOLUME_NAME",
     "name": "$WORKBENCH_NAME",
     "dataProviderURL": "$DATA_PROVIDER_URL",
-    "authSignInURL": "$CORS_ORIGIN_ADDR/login/#/",
-    "authURL": "$CORS_ORIGIN_ADDR/cauth/auth",
+    "authSignInURL": "$SIGNIN_URL",
+    "authURL": "$AUTH_URL",
     "support": {
         "email": "$SUPPORT_EMAIL",
         "forum": "$SUPPORT_FORUM",

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -99,6 +99,7 @@ if [ "$1" = 'apiserver' ]; then
 cat << EOF > /apiserver.json
 {
     "port": "30001",
+    "adminPort": "30002",
     "origin": "$CORS_ORIGIN_ADDR",
     "timeout": $TIMEOUT,
     "requireApproval": $REQUIRE_APPROVAL,

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -4,6 +4,7 @@ package config
 type Config struct {
 	Name            string        `json:"name"`
 	Port            string        `json:"port"`
+	AdminPort       string        `json:"adminPort"`
 	Origin          string        `json:"origin"`
 	Timeout         int           `json:"timeout"`
 	Prefix          string        `json:"prefix"`


### PR DESCRIPTION
* Added second HTTP endpoint to apiserver app to handle trusted requests, by default listens on 30002
* Parameterized auth signin/auth URLs used for ingress creation 
* Added RegisterUserOauth  endpoint to serve as upstream from oauth2 proxy, receive request, process headers, create/update account, create JWT cookie, redirect.