### PR TITLE
Create simple travis script to verify basics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# Run workbench in minikube
+sudo: required
+
+script:
+  - cd apiserver; docker build -t apiserver .


### PR DESCRIPTION
# Problem
As part of [NDS-1151](https://opensource.ncsa.illinois.edu/jira/browse/NDS-1151) I created a Travis-CI build attached to this repo. Development of the definitive `.travis.yml` has been slow due to ongoing changes to the nds labs deploy tools. In the mean time, builds in master have generated broken builds in Travis.

# Approach 
I created a simplified `.travis.yml` that just builds the docker image which requires a successful compile of the application code. This is a pretty good first test and the build now succeeds. 

I would like to merge this into master and then put the bigger travis build into the backlog to address once the deploy process settles down.

# How to test
Visit the travis dashboard for the [NDS Labs project](https://travis-ci.org/nds-org/ndslabs/branches). Select _Trigger Build_ from the menu and chose the `NDS1151-TravisCIFixMaster` branch and observe that the build completes successfully.
