### PR TITLE
Allow user to configure nodeSelector for Workbench API server

### DIFF
--- a/apiserver/apiserver.json
+++ b/apiserver/apiserver.json
@@ -18,7 +18,9 @@
         "maxMessages": 100
     },
     "kubernetes": {
-        "address": "https://minikube-ip:8443"
+        "address": "https://minikube-ip:8443",
+        "nodeSelectorName": "",
+        "nodeSelectorValue": ""
     },
     "email": {
         "host": "",

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -195,6 +195,7 @@ func (s *Server) start(cfg *config.Config, adminPasswd string) {
 	glog.Infof("Using kube-apiserver %s", cfg.Kubernetes.Address)
 	glog.Infof("Using ome volume %s", cfg.HomeVolume)
 	glog.Infof("Using specs dir %s", cfg.Specs.Path)
+	glog.Infof("Using nodeSelector %s: %s", cfg.Kubernetes.NodeSelectorName, cfg.Kubernetes.NodeSelectorValue)
 	glog.Infof("Listening on port %s", cfg.Port)
 
 	homeVol := s.getHomeVolume()
@@ -1949,7 +1950,10 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 
 	// Create the controller template
 	account, _ := s.etcd.GetAccount(userId)
-	template := s.kube.CreateControllerTemplate(userId, name, stack.Id, s.domain, account.EmailAddress, s.email.Server, stackService, spec, addrPortMap, &extraVols)
+        cfg := s.Config
+	nodeSelectorName := cfg.Kubernetes.NodeSelectorName
+	nodeSelectorValue := cfg.Kubernetes.NodeSelectorValue
+	template := s.kube.CreateControllerTemplate(userId, name, stack.Id, s.domain, account.EmailAddress, s.email.Server, stackService, spec, addrPortMap, &extraVols, nodeSelectorName, nodeSelectorValue)
 
 	homeVol := s.getHomeVolume()
 	if len(stackService.VolumeMounts) > 0 || len(spec.VolumeMounts) > 0 {

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -142,7 +142,9 @@ cat << EOF > /apiserver.json
         "address": "$KUBERNETES_ADDR",
         "username": "admin",
         "password": "admin",
-    	"tokenPath": "$TOKEN_PATH"
+    	"tokenPath": "$TOKEN_PATH",
+	"nodeSelectorName": "$NODE_SELECTOR_NAME",
+	"nodeSelectorValue": "$NODE_SELECTOR_VALUE"
     },
     "email": {
         "host": "$SMTP_HOST",

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -52,10 +52,12 @@ type Etcd struct {
 	MaxMessages int    `json:"maxMessages"`
 }
 type Kubernetes struct {
-	Address   string `json:"address"`
-	TokenPath string `json:"tokenPath"`
-	Username  string `json:"username"`
-	Password  string `json:"password"`
+	Address            string `json:"address"`
+	TokenPath          string `json:"tokenPath"`
+	Username           string `json:"username"`
+	Password           string `json:"password"`
+	NodeSelectorName   string `json:"nodeSelectorName"`
+	NodeSelectorValue  string `json:"nodeSelectorValue"`
 }
 type Email struct {
 	Host string `json:"host"`

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -398,7 +398,7 @@ func (k *KubeHelper) CreateServiceTemplate(name string, stack string, spec *ndsa
 
 func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack string, domain string,
 	emailAddress string, smtpHost string, stackService *ndsapi.StackService, spec *ndsapi.ServiceSpec,
-	links *map[string]ServiceAddrPort, extraVols *[]config.Volume) *v1.ReplicationController {
+	links *map[string]ServiceAddrPort, extraVols *[]config.Volume, nodeSelectorName string, nodeSelectorValue string) *v1.ReplicationController {
 
 	k8rc := v1.ReplicationController{}
 
@@ -540,9 +540,17 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 				},
 			},
 			NodeSelector: map[string]string{
-				"ndslabs-role-compute": "true",
+				//"ndslabs-role-compute": "true",
 			},
 		},
+	}
+
+	if nodeSelectorName != "" {
+		if nodeSelectorValue != "" {
+			k8template.Spec.NodeSelector[nodeSelectorName] = nodeSelectorValue
+		} else {
+			k8template.Spec.NodeSelector[nodeSelectorName] = "true"
+		}
 	}
 
 	if spec.ReadyProbe.Path != "" {


### PR DESCRIPTION
# Problem
Fixes https://github.com/cheese-hub/cheesehub/issues/18

# Approach
Add a config option to `apiserver.json` to allow the user to override the `nodeSelector` assigned to spawned applications/stacks.

# How to Test

1. Clone / checkout this branch
2. `./build.sh local`
3. Update `apiserver.json` to point at your Kubernetes API, clear out the values for `nodeSelectorName` / `nodeSelectorValue`
    * This should run stacks/applications on **any** node
4. Start your apiserver, then switch to a second terminal
5. Run the tests in the `postman/` directory in your second terminal, then switch to a third terminal
6. While the tests are running in the background, use your third terminal to `kubectl get pods -n test --watch`
    * Wait for the tests to enter the "StartStack" test case
    * You should see a pod appear under the result for `kubectl get pods`
7. Quickly, before it disappears, run `kubectl get pods -n test -o yaml`
    * Confirm that `nodeSelector` is not present
8. Stop the tests, shut down your API server, and change `apiserver.json` to specify a `nodeSelectorName` and `nodeSelectorValue` (e.g. `fake-node-role=asdf`)
9. Rerun the server and the tests with the new configuration
    * This time, your pods should stay in `Pending` and cannot be scheduled
10. Run `kubectl get pods -n test -o yaml` before the pod shuts down
    * This time, you should see a `nodeSelector` matching your desired label