### PR TITLE
Support real PVCs as a replacement GLFS + hostPath

### DIFF
--- a/apiserver/apiserver.json
+++ b/apiserver/apiserver.json
@@ -5,7 +5,7 @@
     "domain" : "workbench.local",
     "ingress": "LoadBalancer",
     "supportEmail": "",
-    "homeVolume": "global",
+    "homePvcSuffix": "-home",
     "defaultLimits": {
         "cpuMax": 2000,
         "cpuDefault": 1000,
@@ -31,11 +31,7 @@
     "specs": {
         "path": "/path/to/ndslabs-specs"
     },
-    "volumes": [{
-        "name": "global",
-        "path": "/tmp/data",
-        "type": "gluster"
-    }],
+    "volumes": [],
 	"support": {
 		"email": "you@email.org",
 		"forum": "",

--- a/apiserver/apiserver.json
+++ b/apiserver/apiserver.json
@@ -19,6 +19,7 @@
     },
     "kubernetes": {
         "address": "https://minikube-ip:8443",
+        "pvcStorageClass": "",
         "nodeSelectorName": "",
         "nodeSelectorValue": ""
     },

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -38,7 +38,6 @@ import (
 
 var adminUser = "admin"
 var systemNamespace = "kube-system"
-var glusterPodName = "glfs-server-global"
 
 type Server struct {
 	Config          *config.Config
@@ -48,7 +47,7 @@ type Server struct {
 	email           *email.EmailHelper
 	Namespace       string
 	local           bool
-	homeVolume      string
+	homePvcSuffix   string
 	hostname        string
 	jwt             *jwt.JWTMiddleware
 	prefix          string
@@ -172,7 +171,7 @@ func main() {
 	server.kube = kube
 	server.email = email
 	server.Config = cfg
-	server.homeVolume = cfg.HomeVolume
+	server.homePvcSuffix = cfg.HomePvcSuffix
 	server.requireApproval = cfg.RequireApproval
 
 	server.ingress = config.IngressTypeNodePort
@@ -193,13 +192,10 @@ func (s *Server) start(cfg *config.Config, adminPasswd string) {
 	glog.Infof("Starting Workbench API server (%s %s)", version.VERSION, version.BUILD_DATE)
 	glog.Infof("Using etcd %s ", cfg.Etcd.Address)
 	glog.Infof("Using kube-apiserver %s", cfg.Kubernetes.Address)
-	glog.Infof("Using ome volume %s", cfg.HomeVolume)
+	glog.Infof("Using home pvc suffix %s", cfg.HomePvcSuffix)
 	glog.Infof("Using specs dir %s", cfg.Specs.Path)
 	glog.Infof("Using nodeSelector %s: %s", cfg.Kubernetes.NodeSelectorName, cfg.Kubernetes.NodeSelectorValue)
 	glog.Infof("Listening on port %s", cfg.Port)
-
-	homeVol := s.getHomeVolume()
-	os.MkdirAll(homeVol.Path, 0777)
 
 	api := rest.NewApi()
 	api.Use(rest.DefaultDevStack...)
@@ -458,9 +454,9 @@ func (s *Server) initExistingAccounts() {
 		if !s.kube.NamespaceExists(account.Namespace) && account.Status == api.AccountStatusApproved {
 			s.kube.CreateNamespace(account.Namespace)
 
-                        // Create a PVC for this data mount
+                        // Create a PVC for this user's data
 			storageClass := s.Config.Kubernetes.StorageClass
-                        claimName := account.Namespace + "-home" 
+                        claimName := account.Namespace + s.Config.HomePvcSuffix
                         s.kube.CreatePersistentVolumeClaim(account.Namespace, claimName, storageClass)
 
 			if account.ResourceLimits.CPUMax > 0 &&
@@ -614,6 +610,7 @@ func (s *Server) GetAccount(w rest.ResponseWriter, r *rest.Request) {
 	}
 
 	glog.V(4).Infof("Getting account %s\n", userId)
+
 	account, err := s.etcd.GetAccount(userId)
 	if err != nil {
 		rest.NotFound(w, r)
@@ -736,9 +733,9 @@ func (s *Server) setupAccount(account *api.Account) error {
 		return err
 	}
 
-        // Create a PVC for this data mount
+        // Create a PVC for this user's data
 	storageClass := s.Config.Kubernetes.StorageClass
-        claimName := account.Namespace + "-home"
+        claimName := account.Namespace + s.Config.HomePvcSuffix
         s.kube.CreatePersistentVolumeClaim(account.Namespace, claimName, storageClass)
 
 	if account.ResourceLimits == (api.AccountResourceLimits{}) {
@@ -761,11 +758,6 @@ func (s *Server) setupAccount(account *api.Account) error {
 	_, err = s.kube.CreateLimitRange(account.Namespace,
 		account.ResourceLimits.CPUDefault,
 		account.ResourceLimits.MemoryDefault)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.updateStorageQuota(account)
 	if err != nil {
 		return err
 	}
@@ -961,54 +953,6 @@ func (s *Server) DenyAccount(w rest.ResponseWriter, r *rest.Request) {
 	}
 }
 
-func (s *Server) updateStorageQuota(account *api.Account) (bool, error) {
-
-	homeVol := s.getHomeVolume()
-	err := os.MkdirAll(homeVol.Path+"/"+account.Namespace, 0777)
-	if err != nil {
-		return false, err
-	}
-
-	// Get the GFS server pods
-	gfs, err := s.kube.GetPods(systemNamespace, "name", glusterPodName)
-	if err != nil {
-		return false, err
-	}
-	if len(gfs.Items) > 0 {
-		cmd := []string{"gluster", "volume", "quota", homeVol.Name, "limit-usage", "/" + account.Namespace, fmt.Sprintf("%dGB", account.ResourceLimits.StorageQuota)}
-		_, err := s.kube.ExecCommand(systemNamespace, gfs.Items[0].Name, cmd)
-		if err != nil {
-			return false, err
-		}
-	} else {
-		glog.V(2).Info("No GFS servers found, cannot set account quota")
-	}
-	return true, nil
-}
-
-// For now, just call the status command and see if it returns an error
-func (s *Server) getGlusterStatus() (bool, error) {
-
-	homeVol := s.getHomeVolume()
-	// Get the GFS server pods
-	gfs, err := s.kube.GetPods(systemNamespace, "name", glusterPodName)
-	if err != nil {
-		return false, err
-	}
-
-	glog.Infof("Ok Gluster pods of %s size = %d or %d\n", glusterPodName, len(gfs.Items), len(gfs.Items))
-	if len(gfs.Items) > 0 {
-		cmd := []string{"gluster", "volume", "status", homeVol.Name}
-		_, err := s.kube.ExecCommand(systemNamespace, gfs.Items[0].Name, cmd)
-		if err != nil {
-			return false, err
-		}
-	} else {
-		glog.V(2).Info("No GFS servers found, GFS not enabled")
-	}
-	return true, nil
-}
-
 func (s *Server) PutAccount(w rest.ResponseWriter, r *rest.Request) {
 	userId := r.PathParam("userId")
 
@@ -1020,13 +964,6 @@ func (s *Server) PutAccount(w rest.ResponseWriter, r *rest.Request) {
 
 	account := api.Account{}
 	err := r.DecodeJsonPayload(&account)
-	if err != nil {
-		glog.Error(err)
-		rest.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	_, err = s.updateStorageQuota(&account)
 	if err != nil {
 		glog.Error(err)
 		rest.Error(w, err.Error(), http.StatusInternalServerError)
@@ -1080,13 +1017,6 @@ func (s *Server) DeleteAccount(w rest.ResponseWriter, r *rest.Request) {
 		return
 	}
 
-	homeVol := s.getHomeVolume()
-	err = os.RemoveAll(homeVol.Path + "/" + userId)
-	if err != nil {
-		glog.Error(err)
-		rest.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1933,30 +1863,26 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 
 	name := fmt.Sprintf("%s-%s", stack.Id, spec.Key)
 
-	s.makeDirectories(userId, stackService)
-
 	k8vols := make([]v1.Volume, 0)
 	extraVols := make([]config.Volume, 0)
 
+        // Mount the home directory
+        k8homeVol := v1.Volume{}
+        k8homeVol.Name = "home"
+        k8homeVol.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
+                ClaimName: userId + s.Config.HomePvcSuffix,
+        }
+        k8vols = append(k8vols, k8homeVol)
+
 	for _, volume := range s.Config.Volumes {
-		if volume.Name == s.homeVolume {
-			// Mount the home directory
-			k8homeVol := v1.Volume{}
-			k8homeVol.Name = "home"
-			k8homeVol.PersistentVolumeClaim = &v1.PersistentVolumeClaimVolumeSource{
-				ClaimName: userId + "-home",
-			}
-			k8vols = append(k8vols, k8homeVol)
-		} else {
-			// TODO: should "shared" volumes continue to use hostPath?
-			extraVols = append(extraVols, volume)
-			k8vol := v1.Volume{}
-			k8vol.Name = volume.Name
-			k8vol.HostPath = &v1.HostPathVolumeSource{
-				Path: volume.Path,
-			}
-			k8vols = append(k8vols, k8vol)
+		// TODO: should "shared" volumes continue to use hostPath?
+		extraVols = append(extraVols, volume)
+		k8vol := v1.Volume{}
+		k8vol.Name = volume.Name
+		k8vol.HostPath = &v1.HostPathVolumeSource{
+			Path: volume.Path,
 		}
+		k8vols = append(k8vols, k8vol)
 	}
 
 	// Create the controller template
@@ -1965,6 +1891,9 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 	nodeSelectorName := cfg.Kubernetes.NodeSelectorName
 	nodeSelectorValue := cfg.Kubernetes.NodeSelectorValue
 	template := s.kube.CreateControllerTemplate(userId, name, stack.Id, s.domain, account.EmailAddress, s.email.Server, stackService, spec, addrPortMap, &extraVols, nodeSelectorName, nodeSelectorValue)
+
+	jsonTemplate, _ := json.MarshalIndent(template, "", "   ")
+	glog.V(4).Infof("Template:\n%s", jsonTemplate)
 
 	storageClass := s.Config.Kubernetes.StorageClass
 	if len(stackService.VolumeMounts) > 0 || len(spec.VolumeMounts) > 0 {
@@ -2297,22 +2226,6 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 	s.etcd.PutStack(userId, sid, stack)
 
 	return stack, nil
-}
-
-func (s *Server) makeDirectories(userId string, stackService *api.StackService) {
-	for path, _ := range stackService.VolumeMounts {
-		homeVol := s.getHomeVolume()
-		os.MkdirAll(homeVol.Path+"/"+userId+"/"+path, 0777)
-	}
-}
-
-func (s *Server) getHomeVolume() *config.Volume {
-	for _, vol := range s.Config.Volumes {
-		if vol.Name == s.homeVolume {
-			return &vol
-		}
-	}
-	return nil
 }
 
 func (s *Server) getStackWithStatus(userId string, sid string) (*api.Stack, error) {
@@ -3023,14 +2936,6 @@ func (s *Server) GetHealthz(w rest.ResponseWriter, r *rest.Request) {
 		return
 	}
 
-	// TODO: Remove this once PVCs are supported?
-	// Confirm access to Gluster and GFS
-	//_, err = s.getGlusterStatus()
-	//if err != nil {
-	//	rest.Error(w, "GFS not available", http.StatusInternalServerError)
-	//	return
-	//}
-
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -3242,9 +3147,11 @@ func (s *Server) checkIngress(uid string, host string) (bool, error) {
 	return false, nil
 }
 
+// FIXME: Revisit this after adding PVC support
+// See https://github.com/nds-org/ndslabs/issues/262
 // Write the oauth2 payload to the users home directory for access from applications
 func (s *Server) writeAuthPayload(userId string, tokens map[string]string) error {
-	path := s.getHomeVolume().Path + "/" + userId + "/.globus"
+	/*path := s.getHomeVolume().Path + "/" + userId + "/.globus"
 	os.MkdirAll(path, 0777)
 
 	json, err := json.MarshalIndent(tokens, "", "   ")
@@ -3255,7 +3162,7 @@ func (s *Server) writeAuthPayload(userId string, tokens map[string]string) error
 	err = ioutil.WriteFile(path+"/oauth2.json", json, 0777)
 	if err != nil {
 		return err
-	}
+	}*/
 	return nil
 }
 

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1002,7 +1002,14 @@ func (s *Server) DeleteAccount(w rest.ResponseWriter, r *rest.Request) {
 	}
 
 	if s.kube.NamespaceExists(userId) {
-		err := s.kube.DeleteNamespace(userId)
+ 		claimName := userId + s.Config.HomePvcSuffix
+		err := s.kube.DeletePersistentVolumeClaim(userId, claimName)
+		if err != nil {
+			glog.Error(err)
+			rest.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		err = s.kube.DeleteNamespace(userId)
 		if err != nil {
 			glog.Error(err)
 			rest.Error(w, err.Error(), http.StatusInternalServerError)

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -154,7 +154,6 @@ cat << EOF > /apiserver.json
         {
             "name": "$SHARED_VOLUME_NAME",
             "path": "$SHARED_VOLUME_PATH",
-            "type": "local",
             "readOnly": $SHARED_VOLUME_READ_ONLY
         }
     ]

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -32,12 +32,8 @@ if [ "$1" = 'apiserver' ]; then
 		INGRESS="NodePort"
 	fi
 
-	if [ -z "$VOLUME_PATH" ]; then 
-		VOLUME_PATH="/volumes"
-	fi
-
-	if [ -z "$VOLUME_NAME" ]; then 
-		VOLUME_NAME="global"
+	if [ -z "$HOME_PVC_SUFFIX" ]; then 
+		HOME_PVC_SUFFIX="-home"
 	fi
 
 	if [ -z "$SHARED_VOLUME_PATH" ]; then 
@@ -116,7 +112,7 @@ cat << EOF > /apiserver.json
     "ingress": "$INGRESS",
     "username": "admin",
     "password": "admin",
-    "homeVolume": "$VOLUME_NAME",
+    "homePvcSuffix": "$HOME_PVC_SUFFIX",
     "name": "$WORKBENCH_NAME",
     "dataProviderURL": "$DATA_PROVIDER_URL",
     "authSignInURL": "$SIGNIN_URL",
@@ -155,13 +151,8 @@ cat << EOF > /apiserver.json
         "path": "/specs"
     },
     "volumes": [
-	    {
-            "name": "$VOLUME_NAME",
-            "path": "$VOLUME_PATH",
-            "type": "local"
-        }, 
-		{
-			"name": "$SHARED_VOLUME_NAME",
+        {
+            "name": "$SHARED_VOLUME_NAME",
             "path": "$SHARED_VOLUME_PATH",
             "type": "local",
             "readOnly": $SHARED_VOLUME_READ_ONLY

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -36,6 +36,10 @@ if [ "$1" = 'apiserver' ]; then
 		HOME_PVC_SUFFIX="-home"
 	fi
 
+	if [ -z "$PVC_STORAGE_CLASS" ]; then 
+		PVC_STORAGE_CLASS="nfs"
+	fi
+
 	if [ -z "$SHARED_VOLUME_PATH" ]; then 
 		SHARED_VOLUME_PATH="/shared"
 	fi
@@ -140,7 +144,8 @@ cat << EOF > /apiserver.json
         "password": "admin",
     	"tokenPath": "$TOKEN_PATH",
 	"nodeSelectorName": "$NODE_SELECTOR_NAME",
-	"nodeSelectorValue": "$NODE_SELECTOR_VALUE"
+	"nodeSelectorValue": "$NODE_SELECTOR_VALUE",
+	"pvcStorageClass": "$PVC_STORAGE_CLASS"
     },
     "email": {
         "host": "$SMTP_HOST",

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	Kubernetes      Kubernetes    `json:"kubernetes"`
 	Email           Email         `json:"email"`
 	Specs           Specs         `json:"specs"`
-	HomeVolume      string        `json:"homeVolume"`
+	HomePvcSuffix   string        `json:"homePvcSuffix"`
 	Volumes         []Volume      `json:"volumes"`
 	Support         SupportLinks  `json:"support"`
 	AuthURL         string        `json:"authURL"`

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -35,7 +35,6 @@ type Specs struct {
 type Volume struct {
 	Path     string     `json:"path"`
 	Name     string     `json:"name"`
-	Type     VolumeType `json:"type"`
 	ReadOnly bool       `json:"readOnly"`
 }
 
@@ -71,12 +70,4 @@ type IngressType string
 const (
 	IngressTypeLoadBalancer IngressType = "LoadBalancer"
 	IngressTypeNodePort     IngressType = "NodePort"
-)
-
-type VolumeType string
-
-const (
-	VolumeTypeGluster VolumeType = "gluster"
-	VolumeTypeNFS     VolumeType = "nfs"
-	VolumeTypeLocal   VolumeType = "local"
 )

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -58,6 +58,7 @@ type Kubernetes struct {
 	Password           string `json:"password"`
 	NodeSelectorName   string `json:"nodeSelectorName"`
 	NodeSelectorValue  string `json:"nodeSelectorValue"`
+	StorageClass       string `json:"pvcStorageClass"`
 }
 type Email struct {
 	Host string `json:"host"`

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -518,17 +518,6 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 		k8volMounts = append(k8volMounts, k8vol)
 	}
 
-	if len(spec.VolumeMounts) > 0 {
-		for i, vol := range spec.VolumeMounts {
-			volName := fmt.Sprintf("vol%d", i)
-			if vol.Type == ndsapi.MountTypeDocker {
-				volName = "docker"
-			}
-			k8vol := v1.VolumeMount{Name: volName, MountPath: vol.MountPath}
-			k8volMounts = append(k8volMounts, k8vol)
-		}
-	}
-
 	k8cps := []v1.ContainerPort{}
 	if len(spec.Ports) > 0 {
 		for _, port := range spec.Ports {

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -812,6 +812,7 @@ func (k *KubeHelper) CreateIngress(pid string, domain string, service string, po
 	}
 
 	annotations := map[string]string{}
+	annotations["kubernetes.io/ingress.class"] = "nginx"
 	if enableAuth {
 		annotations["nginx.ingress.kubernetes.io/auth-signin"] = k.authSignInURL
 		annotations["nginx.ingress.kubernetes.io/auth-url"] = k.authURL

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -425,12 +425,12 @@ func (k *KubeHelper) CreatePersistentVolumeClaim(ns string, name string, storage
                 k8pvc.Spec.StorageClassName = &storageClass
         }
 
-        rslt, err := k.kubeGo.CoreV1().PersistentVolumeClaims(ns).Create(&k8pvc)
+        _, err := k.kubeGo.CoreV1().PersistentVolumeClaims(ns).Create(&k8pvc)
 
         // Give Kubernetes time to bind a PersistentVolume for this PVC
-        time.Sleep(time.Second * 5)
+        //time.Sleep(time.Second * 5)
 
-	if rslt == nil { 
+	if err != nil { 
                 glog.Errorf("Error creating PVC %s in namespace %s: %s\n", name, ns, err)
 	}
 

--- a/apiserver/postman/Workbench.postman_collection.json
+++ b/apiserver/postman/Workbench.postman_collection.json
@@ -1,14 +1,13 @@
 {
 	"info": {
-		"name": "Workbench",
-		"_postman_id": "b18647a8-5cad-d8f1-e4f6-c723029b73da",
+		"name": "Workbench HTTPS",
+		"_postman_id": "0ece649e-c3a9-b2b3-1aac-d35d9d1815a6",
 		"description": "",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "Accounts",
-			"description": "",
 			"item": [
 				{
 					"name": "Admin login",
@@ -16,8 +15,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bbef9fba-3785-4c54-a66c-c52cdf3375e5",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -29,7 +26,9 @@
 									"    pm.response.to.be.json",
 									"    pm.environment.set(\"admin_token\", jsonData.token);",
 									"});"
-								]
+								],
+								"id": "bbef9fba-3785-4c54-a66c-c52cdf3375e5",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -73,11 +72,11 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "86864787-7661-4b38-bfdc-e1a57b89419f",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"id": "86864787-7661-4b38-bfdc-e1a57b89419f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -126,15 +125,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a57af2dc-16c0-4278-8ccb-090785606bcc",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "a57af2dc-16c0-4278-8ccb-090785606bcc",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -158,7 +157,10 @@
 								"value": "Bearer {{admin_token}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "https://{{host}}/api/log_level/4",
 							"protocol": "https",
@@ -180,8 +182,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "80e76211-7a8b-452b-80f8-5afe7d39b69c",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -194,7 +194,9 @@
 									"    pm.expect(jsonData.status).to.eql(\"unverified\");",
 									"});",
 									""
-								]
+								],
+								"id": "80e76211-7a8b-452b-80f8-5afe7d39b69c",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -238,8 +240,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ebf0e9da-b0b0-41f7-8731-07b6ecfa3701",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -257,7 +257,9 @@
 									"    }    ",
 									"});",
 									""
-								]
+								],
+								"id": "ebf0e9da-b0b0-41f7-8731-07b6ecfa3701",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -305,13 +307,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a8ee1d36-7c33-4116-83fe-7cdaa558190d",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "a8ee1d36-7c33-4116-83fe-7cdaa558190d",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -356,8 +358,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8e6e6490-c630-4004-bdbe-c91706e5b3e3",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -377,7 +377,9 @@
 									"    }    ",
 									"});",
 									""
-								]
+								],
+								"id": "8e6e6490-c630-4004-bdbe-c91706e5b3e3",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -425,15 +427,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e6421c7e-1f85-4275-b96f-a992ad3b9f74",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "e6421c7e-1f85-4275-b96f-a992ad3b9f74",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -474,14 +476,14 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "u",
-									"value": "{{username}}",
-									"equals": true
+									"value": "{{username}}"
 								},
 								{
+									"equals": true,
 									"key": "t",
-									"value": "{{account_token}}",
-									"equals": true
+									"value": "{{account_token}}"
 								}
 							]
 						}
@@ -494,8 +496,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0c98c057-a00c-42c3-88db-2b7567189936",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -514,7 +514,9 @@
 									"    }",
 									"});",
 									""
-								]
+								],
+								"id": "0c98c057-a00c-42c3-88db-2b7567189936",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -562,15 +564,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -619,8 +621,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "80e76211-7a8b-452b-80f8-5afe7d39b69c",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -633,7 +633,9 @@
 									"    pm.expect(jsonData.status).to.eql(\"unverified\");",
 									"});",
 									""
-								]
+								],
+								"id": "80e76211-7a8b-452b-80f8-5afe7d39b69c",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -677,13 +679,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a8ee1d36-7c33-4116-83fe-7cdaa558190d",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "a8ee1d36-7c33-4116-83fe-7cdaa558190d",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -728,8 +730,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "791021c3-39d3-4538-a9f2-8eb4abc9a5c4",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -747,7 +747,9 @@
 									"    }",
 									"});",
 									""
-								]
+								],
+								"id": "791021c3-39d3-4538-a9f2-8eb4abc9a5c4",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -795,14 +797,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fad97748-0a9e-4e1a-a8a5-d58a93fd902f",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "fad97748-0a9e-4e1a-a8a5-d58a93fd902f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -843,14 +845,14 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "u",
-									"value": "{{username}}",
-									"equals": true
+									"value": "{{username}}"
 								},
 								{
+									"equals": true,
 									"key": "t",
-									"value": "{{account_token}}",
-									"equals": true
+									"value": "{{account_token}}"
 								}
 							]
 						}
@@ -863,8 +865,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "17513fc8-40a6-4740-aef2-d79d723fe6da",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -881,7 +881,9 @@
 									"    }",
 									"});",
 									""
-								]
+								],
+								"id": "17513fc8-40a6-4740-aef2-d79d723fe6da",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -929,8 +931,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "84803720-81c4-4fb0-813b-98f946dd9d57",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -944,7 +944,9 @@
 									"    pm.expect(jsonData.status).to.eql(\"approved\");",
 									"});",
 									""
-								]
+								],
+								"id": "84803720-81c4-4fb0-813b-98f946dd9d57",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -993,8 +995,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5208cf0c-895a-46f6-aee6-bc71f6dff67b",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -1008,7 +1008,9 @@
 									"    pm.expect(jsonData.name).to.eql(\"Test Post User\");",
 									"});",
 									""
-								]
+								],
+								"id": "5208cf0c-895a-46f6-aee6-bc71f6dff67b",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1056,15 +1058,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "be130786-184f-4e8e-ae18-adc8bd648fa0",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(409);",
 									"});",
 									""
-								]
+								],
+								"id": "be130786-184f-4e8e-ae18-adc8bd648fa0",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1112,8 +1114,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5757c938-f763-4d90-8891-35c533da3652",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -1126,7 +1126,9 @@
 									"    pm.expect(jsonData.account.id).to.eql(\"testpost\");",
 									"});",
 									""
-								]
+								],
+								"id": "5757c938-f763-4d90-8891-35c533da3652",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1175,8 +1177,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "17e38f49-52d0-4e97-ab47-482256b858d2",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -1190,7 +1190,9 @@
 									"    pm.expect(jsonData.name).to.eql(\"Test Put User\");",
 									"});",
 									""
-								]
+								],
+								"id": "17e38f49-52d0-4e97-ab47-482256b858d2",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1239,15 +1241,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1296,8 +1298,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "35c3fc15-2148-448a-874b-f9b2405b03ef",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -1311,7 +1311,9 @@
 									"    pm.expect(jsonData.status).to.eql(\"approved\");",
 									"});",
 									""
-								]
+								],
+								"id": "35c3fc15-2148-448a-874b-f9b2405b03ef",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1360,8 +1362,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5ec7f0c2-6512-41e0-816c-6d26629a1c15",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -1375,7 +1375,9 @@
 									"    pm.expect(jsonData.status).to.eql(\"approved\");",
 									"});",
 									""
-								]
+								],
+								"id": "5ec7f0c2-6512-41e0-816c-6d26629a1c15",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1424,15 +1426,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1481,8 +1483,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1495,7 +1495,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1539,15 +1541,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "54c6c1e3-3705-4f46-a1e2-1bcc4bd0254f",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(403);",
 									"});",
 									""
-								]
+								],
+								"id": "54c6c1e3-3705-4f46-a1e2-1bcc4bd0254f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1595,15 +1597,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9c476f1e-69af-4b80-bd52-9bdaab9afa10",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(403);",
 									"});",
 									""
-								]
+								],
+								"id": "9c476f1e-69af-4b80-bd52-9bdaab9afa10",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1649,7 +1651,6 @@
 		},
 		{
 			"name": "Authentication",
-			"description": "",
 			"item": [
 				{
 					"name": "Invalid login",
@@ -1657,14 +1658,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d971b9a5-a29c-470c-bb99-a0c74a9e9d0b",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(401);",
 									"});",
 									""
-								]
+								],
+								"id": "d971b9a5-a29c-470c-bb99-a0c74a9e9d0b",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1708,8 +1709,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1722,7 +1721,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1766,8 +1767,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1780,7 +1779,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1824,14 +1825,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "18b21c2c-2fa9-4fe9-a7e5-0e37716f3ed0",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(403);",
 									"});",
 									""
-								]
+								],
+								"id": "18b21c2c-2fa9-4fe9-a7e5-0e37716f3ed0",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1871,9 +1872,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "host",
-									"value": "test",
-									"equals": true
+									"value": "test"
 								}
 							]
 						}
@@ -1886,14 +1887,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "49f2b3d8-c657-4a0d-8dc4-7e43e70ef668",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "49f2b3d8-c657-4a0d-8dc4-7e43e70ef668",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1941,8 +1942,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "44c314d5-3f1c-45ec-a5d3-d209ebde9ce2",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1956,7 +1955,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "44c314d5-3f1c-45ec-a5d3-d209ebde9ce2",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2004,14 +2005,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1da197b0-49b5-49a4-ab6a-731ae82676b3",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "1da197b0-49b5-49a4-ab6a-731ae82676b3",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2059,8 +2060,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -2073,7 +2072,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2117,11 +2118,11 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5f6dc2db-cfbf-4f52-8651-c60589ae0f34",
-								"type": "text/javascript",
 								"exec": [
 									""
-								]
+								],
+								"id": "5f6dc2db-cfbf-4f52-8651-c60589ae0f34",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2169,8 +2170,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -2183,7 +2182,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2227,14 +2228,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1da197b0-49b5-49a4-ab6a-731ae82676b3",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "1da197b0-49b5-49a4-ab6a-731ae82676b3",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2283,15 +2284,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ea296743-aa8a-4c06-90ef-362885829dd8",
-								"type": "text/javascript",
 								"exec": [
 									"// Return 200 regardless",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "ea296743-aa8a-4c06-90ef-362885829dd8",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2340,15 +2341,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "31a14d71-a021-4b5f-8766-02eeb0449503",
-								"type": "text/javascript",
 								"exec": [
 									"// Currently does nothing",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "31a14d71-a021-4b5f-8766-02eeb0449503",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2394,7 +2395,6 @@
 		},
 		{
 			"name": "Services",
-			"description": "",
 			"item": [
 				{
 					"name": "Admin login",
@@ -2402,8 +2402,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "172ac3f1-bddd-439f-bd6a-969392b893f4",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -2415,7 +2413,9 @@
 									"    pm.response.to.be.json",
 									"    pm.environment.set(\"admin_token\", jsonData.token);",
 									"});"
-								]
+								],
+								"id": "172ac3f1-bddd-439f-bd6a-969392b893f4",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2459,14 +2459,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "40cdc37b-0855-4a96-9f87-bdfd7c5e474f",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(500);",
 									"});"
-								]
+								],
+								"id": "40cdc37b-0855-4a96-9f87-bdfd7c5e474f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2506,9 +2506,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -2521,14 +2521,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4cabd350-bb55-4065-96f2-7bb2bb60e39b",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(400);",
 									"});"
-								]
+								],
+								"id": "4cabd350-bb55-4065-96f2-7bb2bb60e39b",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2568,9 +2568,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -2583,14 +2583,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "44f1a522-57fd-4517-bba0-ea3d11b3740f",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "44f1a522-57fd-4517-bba0-ea3d11b3740f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2630,9 +2630,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -2645,8 +2645,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b83839ca-3ac3-4e65-af74-f24ca63fa524",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -2660,7 +2658,9 @@
 									"    pm.expect(jsonData.label).to.eql(\"nginxput\");",
 									"});",
 									""
-								]
+								],
+								"id": "b83839ca-3ac3-4e65-af74-f24ca63fa524",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2701,9 +2701,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -2716,14 +2716,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1476660d-3e50-4ff8-881c-f607ae575f17",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(409);",
 									"});"
-								]
+								],
+								"id": "1476660d-3e50-4ff8-881c-f607ae575f17",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2763,9 +2763,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -2778,14 +2778,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8802833d-0379-4afe-8a6d-a630607ec77c",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});"
-								]
+								],
+								"id": "8802833d-0379-4afe-8a6d-a630607ec77c",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2825,9 +2825,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -2840,8 +2840,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -2854,7 +2852,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2898,8 +2898,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0a756445-53d6-4268-9897-f052fc27ac45",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -2907,7 +2905,9 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"id": "0a756445-53d6-4268-9897-f052fc27ac45",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -2947,9 +2947,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -2962,8 +2962,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "17b93574-7aa1-4a5e-ac52-177879d21884",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -2977,7 +2975,9 @@
 									"    pm.expect(jsonData.label).to.eql(\"nginxput\");",
 									"});",
 									""
-								]
+								],
+								"id": "17b93574-7aa1-4a5e-ac52-177879d21884",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3018,9 +3018,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3033,8 +3033,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4c5ea647-1295-4ddb-9f02-07925da18ee0",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3042,7 +3040,9 @@
 									"});",
 									"",
 									""
-								]
+								],
+								"id": "4c5ea647-1295-4ddb-9f02-07925da18ee0",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3082,9 +3082,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3097,8 +3097,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "de192048-b984-40f6-965e-d7f6ba40bc55",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3113,7 +3111,9 @@
 									"    pm.expect(jsonData.authRequired).to.eql(true);",
 									"});",
 									""
-								]
+								],
+								"id": "de192048-b984-40f6-965e-d7f6ba40bc55",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3154,9 +3154,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3169,14 +3169,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "52b0d6ce-cedf-4ead-9b9d-91bd9f742ee9",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});"
-								]
+								],
+								"id": "52b0d6ce-cedf-4ead-9b9d-91bd9f742ee9",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3217,9 +3217,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3232,8 +3232,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "54b1f2e0-1069-4bdf-9692-c3768ddad574",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3246,7 +3244,9 @@
 									"    pm.response.to.be.json",
 									"});",
 									""
-								]
+								],
+								"id": "54b1f2e0-1069-4bdf-9692-c3768ddad574",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3287,9 +3287,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -3302,14 +3302,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0329e422-e3d7-4813-8acb-d246e643804c",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});",
 									""
-								]
+								],
+								"id": "0329e422-e3d7-4813-8acb-d246e643804c",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3350,9 +3350,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -3365,8 +3365,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "35cb0e08-4e70-46d9-ab6e-36f029d97040",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3381,7 +3379,9 @@
 									"    pm.expect(jsonData.length).to.eql(1);",
 									"});",
 									""
-								]
+								],
+								"id": "35cb0e08-4e70-46d9-ab6e-36f029d97040",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3421,9 +3421,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3436,15 +3436,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3485,9 +3485,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3500,15 +3500,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a670d11a-f7ad-42db-bbb6-3dcf9b13f2ea",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});",
 									""
-								]
+								],
+								"id": "a670d11a-f7ad-42db-bbb6-3dcf9b13f2ea",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3549,9 +3549,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "user",
-									"equals": true
+									"value": "user"
 								}
 							]
 						}
@@ -3564,15 +3564,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3613,9 +3613,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -3628,8 +3628,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9122026e-0fbb-435c-bcce-6eb80afda5d4",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3643,7 +3641,9 @@
 									"    pm.response.to.be.json",
 									"});",
 									""
-								]
+								],
+								"id": "9122026e-0fbb-435c-bcce-6eb80afda5d4",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3683,9 +3683,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "system",
-									"equals": true
+									"value": "system"
 								}
 							]
 						}
@@ -3698,8 +3698,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9122026e-0fbb-435c-bcce-6eb80afda5d4",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3713,7 +3711,9 @@
 									"    pm.response.to.be.json",
 									"});",
 									""
-								]
+								],
+								"id": "9122026e-0fbb-435c-bcce-6eb80afda5d4",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3753,9 +3753,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "catalog",
-									"value": "all",
-									"equals": true
+									"value": "all"
 								}
 							]
 						}
@@ -3765,8 +3765,7 @@
 			]
 		},
 		{
-			"name": "Stacks",
-			"description": "",
+			"name": "Simple Stacks",
 			"item": [
 				{
 					"name": "User login",
@@ -3774,8 +3773,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -3788,7 +3785,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3827,13 +3826,11 @@
 					"response": []
 				},
 				{
-					"name": "Post stack",
+					"name": "Post simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "de67e65e-457c-4171-b3ed-dcdc07efc207",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3850,7 +3847,9 @@
 									"    pm.environment.set(\"stack_sid\", jsonData.id);",
 									"});",
 									""
-								]
+								],
+								"id": "de67e65e-457c-4171-b3ed-dcdc07efc207",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3893,13 +3892,11 @@
 					"response": []
 				},
 				{
-					"name": "Get stack",
+					"name": "Get simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "fa052fb1-6ed0-4b86-9f0b-9a6b7b866b45",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3916,7 +3913,9 @@
 									"    pm.environment.set(\"stack_ssid\", jsonData.services[0].id);",
 									"});",
 									""
-								]
+								],
+								"id": "fa052fb1-6ed0-4b86-9f0b-9a6b7b866b45",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -3960,20 +3959,20 @@
 					"response": []
 				},
 				{
-					"name": "Start stack",
+					"name": "Start simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "399d5eb3-bd8b-49aa-a20f-d12f500ae400",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(202);",
 									"});",
 									""
-								]
+								],
+								"id": "399d5eb3-bd8b-49aa-a20f-d12f500ae400",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4017,13 +4016,11 @@
 					"response": []
 				},
 				{
-					"name": "Wait for stack start",
+					"name": "Wait for simple stack start",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "cf7deef1-26db-4c4e-8638-388aab72ff88",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -4038,7 +4035,9 @@
 									"} else {",
 									"  postman.setNextRequest(\"Get stack logs\");",
 									"}"
-								]
+								],
+								"id": "cf7deef1-26db-4c4e-8638-388aab72ff88",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4082,20 +4081,20 @@
 					"response": []
 				},
 				{
-					"name": "Get stack logs",
+					"name": "Get simple stack logs",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "12fc5ff4-60cd-475e-a765-241ea5aa4796",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "12fc5ff4-60cd-475e-a765-241ea5aa4796",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4139,19 +4138,19 @@
 					"response": []
 				},
 				{
-					"name": "Stop stack",
+					"name": "Stop simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "d64e0295-db10-4f1c-ba0d-583c951124d5",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(202);",
 									"});"
-								]
+								],
+								"id": "d64e0295-db10-4f1c-ba0d-583c951124d5",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4195,13 +4194,11 @@
 					"response": []
 				},
 				{
-					"name": "Wait for stack stop",
+					"name": "Wait for simple stack stop",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "521dc444-b0c8-46a1-afac-59818e716fcf",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -4216,7 +4213,9 @@
 									"} else {",
 									"  postman.setNextRequest(\"Put stack\");",
 									"}"
-								]
+								],
+								"id": "521dc444-b0c8-46a1-afac-59818e716fcf",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4260,13 +4259,11 @@
 					"response": []
 				},
 				{
-					"name": "Put stack",
+					"name": "Put simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "f5553b62-53d0-4ad8-851e-2d81a6b471b4",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -4283,7 +4280,9 @@
 									"    pm.environment.set(\"stack_sid\", jsonData.id);",
 									"});",
 									""
-								]
+								],
+								"id": "f5553b62-53d0-4ad8-851e-2d81a6b471b4",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4327,13 +4326,11 @@
 					"response": []
 				},
 				{
-					"name": "Put rename stack",
+					"name": "Put rename simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "eb9798f1-df4a-4501-bf04-be08427e93a3",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -4350,7 +4347,9 @@
 									"    pm.environment.set(\"stack_sid\", jsonData.id);",
 									"});",
 									""
-								]
+								],
+								"id": "eb9798f1-df4a-4501-bf04-be08427e93a3",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4395,20 +4394,20 @@
 					"response": []
 				},
 				{
-					"name": "Delete stack",
+					"name": "Delete simple stack",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"id": "35a7bebd-03c8-41c0-95cd-b9e589b99e55",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "35a7bebd-03c8-41c0-95cd-b9e589b99e55",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4451,11 +4450,742 @@
 					},
 					"response": []
 				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "a49656ba-2d0c-4f6c-9fc6-9256f407e759",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "270f5698-f6ef-403e-bf1a-6bc8ff89e9ee",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Complex Stacks",
+			"item": [
+				{
+					"name": "User login",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Check token\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.environment.set(\"token\", jsonData.token);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\": \"{{username}}\", \"password\": \"{{password}}\"}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/authenticate",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"authenticate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Post complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8fb12b44-20fb-4ae1-a4ec-a4c006610833",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.name).to.eql(\"My MongoDB\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"key\": \"mongo\",\n    \"name\": \"My MongoDB\",\n    \"services\": [\n        {\n            \"service\": \"mongo\"\n        }\n    ],\n    \"secure\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d4e696bc-7048-40c3-b9f5-e918671a1471",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.key).to.eql(\"mongo\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);    ",
+									"    pm.environment.set(\"stack_ssid\", jsonData.services[0].id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Start complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "399d5eb3-bd8b-49aa-a20f-d12f500ae400",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/start/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"start",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Wait for complex stack start",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "09aee015-2a2d-45e5-b677-ff9836a7a9bd",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"if (jsonData.status !== \"started\") {",
+									"  postman.setNextRequest(\"Wait for complex stack start\");",
+									"  setTimeout(function() {}, 10000);",
+									"} else {",
+									"  postman.setNextRequest(\"Get complex stack logs\");",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get complex stack logs",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "12fc5ff4-60cd-475e-a765-241ea5aa4796",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/logs/{{stack_ssid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"logs",
+								"{{stack_ssid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Stop complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d64e0295-db10-4f1c-ba0d-583c951124d5",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stop/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stop",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Wait for complex stack stop",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "09980388-e7fd-4b3d-b3b4-9eddbc97cf7f",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"if (jsonData.status !== \"stopped\") {",
+									"  postman.setNextRequest(\"Wait for complex stack stop\");",
+									"  setTimeout(function() {}, 20000);",
+									"} else {",
+									"  postman.setNextRequest(\"Put complex stack\");",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Put complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b18cec3b-5d5e-4b61-ba15-0aa0adb80236",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.name).to.eql(\"Your MongoDB\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"{{stack_sid}}\",\n    \"key\": \"mongo\",\n    \"name\": \"Your MongoDB\",\n    \"services\": [\n        {\n            \"id\": \"{{stack_sid}}-mongo\",\n            \"service\": \"mongo\",\n            \"volumeMounts\": {\n                \"AppData/swh8jq-mongo-6xr7g\": \"/data/db\"\n            }\n        }\n    ],\n    \"secure\": true\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Put rename complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "eb9798f1-df4a-4501-bf04-be08427e93a3",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.name).to.eql(\"New name\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"New name\"\n}"
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks/{{stack_sid}}/rename",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}",
+								"rename"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "35a7bebd-03c8-41c0-95cd-b9e589b99e55",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "https://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "https",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "ecfb4c3d-8400-473e-b755-66d1c23894db",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "8aafb7f6-1477-4176-ab88-8d5f90086599",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
 			]
 		},
 		{
 			"name": "Misc",
-			"description": "",
 			"item": [
 				{
 					"name": "Get healthz",
@@ -4463,13 +5193,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4513,13 +5243,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4563,13 +5293,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4613,13 +5343,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4663,13 +5393,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4713,13 +5443,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4764,13 +5494,13 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6054548d-b167-43eb-8965-aee59331366e",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "6054548d-b167-43eb-8965-aee59331366e",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4816,7 +5546,6 @@
 		},
 		{
 			"name": "Quickstart",
-			"description": "",
 			"item": [
 				{
 					"name": "User login",
@@ -4824,8 +5553,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -4838,7 +5565,9 @@
 									"    pm.environment.set(\"token\", jsonData.token);",
 									"});",
 									""
-								]
+								],
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4882,15 +5611,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7c26b000-3a37-49f5-8b31-515f70165253",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "7c26b000-3a37-49f5-8b31-515f70165253",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -4930,9 +5659,9 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "key",
-									"value": "cloudcmd",
-									"equals": true
+									"value": "cloudcmd"
 								}
 							]
 						}
@@ -5008,8 +5737,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "105fc17d-da64-4a2a-9441-bd09384eeb38",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -5024,7 +5751,9 @@
 									"} else {",
 									"  postman.setNextRequest(\"Get quickstart check console\");",
 									"}"
-								]
+								],
+								"id": "105fc17d-da64-4a2a-9441-bd09384eeb38",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5073,14 +5802,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ff987575-3d2e-47eb-bfcb-79e0e1f8e03d",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});"
-								]
+								],
+								"id": "ff987575-3d2e-47eb-bfcb-79e0e1f8e03d",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5120,14 +5849,14 @@
 							],
 							"query": [
 								{
+									"equals": true,
 									"key": "namespace",
-									"value": "{{username}}",
-									"equals": true
+									"value": "{{username}}"
 								},
 								{
+									"equals": true,
 									"key": "ssid",
-									"value": "{{quickstart_ssid}}",
-									"equals": true
+									"value": "{{quickstart_ssid}}"
 								}
 							]
 						}
@@ -5140,14 +5869,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d64e0295-db10-4f1c-ba0d-583c951124d5",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(202);",
 									"});"
-								]
+								],
+								"id": "d64e0295-db10-4f1c-ba0d-583c951124d5",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5261,15 +5990,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "35a7bebd-03c8-41c0-95cd-b9e589b99e55",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "35a7bebd-03c8-41c0-95cd-b9e589b99e55",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5316,7 +6045,6 @@
 		},
 		{
 			"name": "Cleanup",
-			"description": "",
 			"item": [
 				{
 					"name": "Admin login",
@@ -5324,8 +6052,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d4a4ffdb-2996-48e9-b8f5-ae83b9d56d8b",
-								"type": "text/javascript",
 								"exec": [
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -5337,7 +6063,9 @@
 									"    pm.response.to.be.json",
 									"    pm.environment.set(\"admin_token\", jsonData.token);",
 									"});"
-								]
+								],
+								"id": "d4a4ffdb-2996-48e9-b8f5-ae83b9d56d8b",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5381,15 +6109,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									""
-								]
+								],
+								"id": "b1be56c6-e749-462f-9304-b978966b99cb",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5438,15 +6166,15 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4ab26398-cf16-41be-aac2-ac067fe12efc",
-								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(404);",
 									"});",
 									""
-								]
+								],
+								"id": "4ab26398-cf16-41be-aac2-ac067fe12efc",
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -5490,6 +6218,28 @@
 					"response": []
 				}
 			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "004bb914-e71f-4a44-9c28-5cdea1d8b012",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "f283acf5-3cfc-486c-b98f-8b2e4e37ba50",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
 		}
 	]
 }

--- a/apiserver/postman/Workbench.postman_collection.json
+++ b/apiserver/postman/Workbench.postman_collection.json
@@ -3831,25 +3831,25 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "f66d2585-d43d-4bc3-a5ca-531e4e513275",
+								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"",
 									"var jsonData = pm.response.json();",
 									"",
 									"pm.test(\"JSON response\", function () {",
 									"    pm.response.to.be.json",
-									"    pm.expect(jsonData.name).to.eql(\"My File Manager\");",
+									"    pm.expect(jsonData.key).to.eql(\"cloudcmd\");",
 									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
-									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);    ",
+									"    pm.environment.set(\"stack_ssid\", jsonData.services[0].id);",
 									"});",
 									""
-								],
-								"id": "de67e65e-457c-4171-b3ed-dcdc07efc207",
-								"type": "text/javascript"
+								]
 							}
 						}
 					],
@@ -3897,6 +3897,8 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "b92cf37f-a7d7-4851-9ce7-2cfa4d7bee14",
+								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -3913,9 +3915,7 @@
 									"    pm.environment.set(\"stack_ssid\", jsonData.services[0].id);",
 									"});",
 									""
-								],
-								"id": "fa052fb1-6ed0-4b86-9f0b-9a6b7b866b45",
-								"type": "text/javascript"
+								]
 							}
 						}
 					],
@@ -4021,6 +4021,8 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "2c4aa801-b3de-453c-ad3f-07a461a5deaf",
+								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -4030,14 +4032,12 @@
 									"var jsonData = pm.response.json();",
 									"",
 									"if (jsonData.status !== \"started\") {",
-									"  postman.setNextRequest(\"Wait for stack start\");",
+									"  postman.setNextRequest(\"Wait for simple stack start\");",
 									"  setTimeout(function() {}, 10000);",
 									"} else {",
-									"  postman.setNextRequest(\"Get stack logs\");",
+									"  postman.setNextRequest(\"Get simple stack logs\");",
 									"}"
-								],
-								"id": "cf7deef1-26db-4c4e-8638-388aab72ff88",
-								"type": "text/javascript"
+								]
 							}
 						}
 					],
@@ -4199,6 +4199,8 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "a6aaee8c-d7f4-4e8d-b80d-499542245c70",
+								"type": "text/javascript",
 								"exec": [
 									"",
 									"pm.test(\"HTTP response\", function () {",
@@ -4208,14 +4210,12 @@
 									"var jsonData = pm.response.json();",
 									"",
 									"if (jsonData.status !== \"stopped\") {",
-									"  postman.setNextRequest(\"Wait for stack stop\");",
+									"  postman.setNextRequest(\"Wait for simple stack stop\");",
 									"  setTimeout(function() {}, 20000);",
 									"} else {",
-									"  postman.setNextRequest(\"Put stack\");",
+									"  postman.setNextRequest(\"Put simple stack\");",
 									"}"
-								],
-								"id": "521dc444-b0c8-46a1-afac-59818e716fcf",
-								"type": "text/javascript"
+								]
 							}
 						}
 					],

--- a/apiserver/postman/Workbench.postman_collection_local.json
+++ b/apiserver/postman/Workbench.postman_collection_local.json
@@ -1,14 +1,13 @@
 {
 	"info": {
 		"name": "Workbench",
-		"_postman_id": "b18647a8-5cad-d8f1-e4f6-c723029b73da",
+		"_postman_id": "307cd853-89e0-2a90-c0af-91f44f311356",
 		"description": "",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "Accounts",
-			"description": "",
 			"item": [
 				{
 					"name": "Admin login",
@@ -158,7 +157,10 @@
 								"value": "Bearer {{admin_token}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "http://{{host}}/api/log_level/4",
 							"protocol": "http",
@@ -1649,7 +1651,6 @@
 		},
 		{
 			"name": "Authentication",
-			"description": "",
 			"item": [
 				{
 					"name": "Invalid login",
@@ -2394,7 +2395,6 @@
 		},
 		{
 			"name": "Services",
-			"description": "",
 			"item": [
 				{
 					"name": "Admin login",
@@ -3765,8 +3765,7 @@
 			]
 		},
 		{
-			"name": "Stacks",
-			"description": "",
+			"name": "Simple Stacks",
 			"item": [
 				{
 					"name": "User login",
@@ -3827,7 +3826,7 @@
 					"response": []
 				},
 				{
-					"name": "Post stack",
+					"name": "Post simple stack",
 					"event": [
 						{
 							"listen": "test",
@@ -3893,7 +3892,7 @@
 					"response": []
 				},
 				{
-					"name": "Get stack",
+					"name": "Get simple stack",
 					"event": [
 						{
 							"listen": "test",
@@ -3960,7 +3959,7 @@
 					"response": []
 				},
 				{
-					"name": "Start stack",
+					"name": "Start simple stack",
 					"event": [
 						{
 							"listen": "test",
@@ -4017,7 +4016,7 @@
 					"response": []
 				},
 				{
-					"name": "Wait for stack start",
+					"name": "Wait for simple stack start",
 					"event": [
 						{
 							"listen": "test",
@@ -4082,7 +4081,7 @@
 					"response": []
 				},
 				{
-					"name": "Get stack logs",
+					"name": "Get simple stack logs",
 					"event": [
 						{
 							"listen": "test",
@@ -4139,7 +4138,7 @@
 					"response": []
 				},
 				{
-					"name": "Stop stack",
+					"name": "Stop simple stack",
 					"event": [
 						{
 							"listen": "test",
@@ -4195,7 +4194,7 @@
 					"response": []
 				},
 				{
-					"name": "Wait for stack stop",
+					"name": "Wait for simple stack stop",
 					"event": [
 						{
 							"listen": "test",
@@ -4260,7 +4259,7 @@
 					"response": []
 				},
 				{
-					"name": "Put stack",
+					"name": "Put simple stack",
 					"event": [
 						{
 							"listen": "test",
@@ -4327,7 +4326,7 @@
 					"response": []
 				},
 				{
-					"name": "Put rename stack",
+					"name": "Put rename simple stack",
 					"event": [
 						{
 							"listen": "test",
@@ -4395,7 +4394,695 @@
 					"response": []
 				},
 				{
-					"name": "Delete stack",
+					"name": "Delete simple stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "35a7bebd-03c8-41c0-95cd-b9e589b99e55",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Complex Stacks",
+			"item": [
+				{
+					"name": "User login",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e8d6cb5f-663a-437a-9999-0d09d574719f",
+								"type": "text/javascript",
+								"exec": [
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Check token\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.environment.set(\"token\", jsonData.token);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"username\": \"{{username}}\", \"password\": \"{{password}}\"}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/authenticate",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"authenticate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Post complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8fb12b44-20fb-4ae1-a4ec-a4c006610833",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.name).to.eql(\"My MongoDB\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"key\": \"mongo\",\n    \"name\": \"My MongoDB\",\n    \"services\": [\n        {\n            \"service\": \"mongo\"\n        }\n    ],\n    \"secure\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d4e696bc-7048-40c3-b9f5-e918671a1471",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.key).to.eql(\"mongo\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);    ",
+									"    pm.environment.set(\"stack_ssid\", jsonData.services[0].id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Start complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "399d5eb3-bd8b-49aa-a20f-d12f500ae400",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/start/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"start",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Wait for complex stack start",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "09aee015-2a2d-45e5-b677-ff9836a7a9bd",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"if (jsonData.status !== \"started\") {",
+									"  postman.setNextRequest(\"Wait for complex stack start\");",
+									"  setTimeout(function() {}, 10000);",
+									"} else {",
+									"  postman.setNextRequest(\"Get complex stack logs\");",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get complex stack logs",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "12fc5ff4-60cd-475e-a765-241ea5aa4796",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/logs/{{stack_ssid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"logs",
+								"{{stack_ssid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Stop complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d64e0295-db10-4f1c-ba0d-583c951124d5",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stop/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stop",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Wait for complex stack stop",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "09980388-e7fd-4b3d-b3b4-9eddbc97cf7f",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"if (jsonData.status !== \"stopped\") {",
+									"  postman.setNextRequest(\"Wait for complex stack stop\");",
+									"  setTimeout(function() {}, 20000);",
+									"} else {",
+									"  postman.setNextRequest(\"Put complex stack\");",
+									"}"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"key\": \"nginx\",\n  \"label\": \"nginx\",\n  \"image\": {\n    \"registry\": \"\",\n    \"name\": \"nginx\",\n    \"tags\": [\n      \"latest\"\n    ]\n  },\n  \"display\": \"stack\",\n  \"access\": \"external\",\n  \"ports\": [\n    {\n      \"port\": 80,\n      \"protocol\": \"http\",\n      \"contextPath\": \"/\"\n    }\n  ],\n  \"readinessProbe\": {\n    \"type\": \"\",\n    \"path\": \"\",\n    \"port\": 0,\n    \"initialDelay\": 0,\n    \"timeout\": 0\n  },\n  \"resourceLimits\": {\n    \"cpuMax\": 500,\n    \"cpuDefault\": 100,\n    \"memMax\": 1000,\n    \"memDefault\": 50\n  },\n  \"authRequired\": false,\n  \"privileged\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Put complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b18cec3b-5d5e-4b61-ba15-0aa0adb80236",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.name).to.eql(\"Your MongoDB\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"{{stack_sid}}\",\n    \"key\": \"mongo\",\n    \"name\": \"Your MongoDB\",\n    \"services\": [\n        {\n            \"id\": \"{{stack_sid}}-mongo\",\n            \"service\": \"mongo\",\n            \"volumeMounts\": {\n                \"AppData/swh8jq-mongo-6xr7g\": \"/data/db\"\n            }\n        }\n    ],\n    \"secure\": true\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks/{{stack_sid}}",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Put rename complex stack",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "eb9798f1-df4a-4501-bf04-be08427e93a3",
+								"type": "text/javascript",
+								"exec": [
+									"",
+									"pm.test(\"HTTP response\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"",
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"JSON response\", function () {",
+									"    pm.response.to.be.json",
+									"    pm.expect(jsonData.name).to.eql(\"New name\");",
+									"    pm.expect(jsonData.status).to.eql(\"stopped\");",
+									"    pm.environment.set(\"stack_sid\", jsonData.id);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Origin",
+								"value": "http://{{host}}/"
+							},
+							{
+								"key": "User-Agent",
+								"value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"New name\"\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}/api/stacks/{{stack_sid}}/rename",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"stacks",
+								"{{stack_sid}}",
+								"rename"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete complex stack",
 					"event": [
 						{
 							"listen": "test",
@@ -4455,7 +5142,6 @@
 		},
 		{
 			"name": "Misc",
-			"description": "",
 			"item": [
 				{
 					"name": "Get healthz",
@@ -4816,7 +5502,6 @@
 		},
 		{
 			"name": "Quickstart",
-			"description": "",
 			"item": [
 				{
 					"name": "User login",
@@ -5316,7 +6001,6 @@
 		},
 		{
 			"name": "Cleanup",
-			"description": "",
 			"item": [
 				{
 					"name": "Admin login",


### PR DESCRIPTION
# Problem
Fixes #249. Workbench currently relies on an admittedly fragile storage model.

Currently, we run GlusterFS in a set of server pods (even-numbered) on our storage nodes. On every node in the cluster we run a Gluster client pod as well. The client pod reaches out to the server pods to mount the Gluster volume onto the host machine from within the container.

The reasoning behind this approach was our requirement for ReadWriteMany volume support, and the lack for such support in our initial OpenStack environments. 

# Approach
Now that we have more thoroughly explored PVC support in OpenStack environments without making any assumptions about underlying infrastructure, our cup runneth over with different ways to support dynamically-provisioned ReadWriteMany storage using PVCs.

This new approach does away with the old hostPath / GlusterFS implementation and replaces it with `PersistentVolumeClaims`. Since many types of PVCs can support ReadWriteMany, this opens up several different storage backing options (depending on the scenario):
* `MinikubeStorageProvisioner`: Minikube instances come with the `storage-provisioner` addon enabled by default
* `HostPathProvisioner`: single-node development instances can still use PVCs by using a provisioner that simply performs a `mkdir` locally
* `NFSProvisioner`: small, multi-node clusters can use PVCs the same way, with a provisioner that simply performs a `mkdir` remotely 
* `GlusterfsSimpleProvisioner`: clusters that have heavy storage needs or scalability concerns can opt to use something heavier like GlusterFS - this allows you to add new storage as needed while using GlusterFS for logical volume management (e.g. multiple physical volumes appearing as one logical volume)

# How to test

1. Follow the steps here to get a development environment up and running: https://github.com/nds-org/ndslabs/tree/develop/apiserver
2. Check out this branch: `git fetch --all && git checkout pvc-support`
3. Edit `apiserver.json`
    * At a bare minimum, you'll need to set `kubernetes.address` / `specs.path` / `support.email` / `supportEmail` to point to the correct locations
    * You can leave `kubernetes.pvcStorageClass` blank for now to use the cluster default StorageClass, or specify your own StorageClass here
4. Rebuild and restart the API server:
```bash
./build.sh local
./build/bin/apiserver-darwin-amd64   # For OSX
./build/bin/apiserver-linux-amd64    # For Linux
```
5. Edit `postman/workbench.postman_environment.json` to set the correct values for (at least) the `host` and `email` field
```bash
vi postman/workbench.postman_environment.json
```
6. Use `newman` to run the tests:
```bash
npm install -g newman
cd postman/
newman run --insecure  --environment=workbench.postman_environment.json --delay-request=1000 Workbench.postman_collection_local.json
```
7. Open a new terminal window and execute `kubectl get pvc ,n test --watch`
    * You should see a new line item when PVCs are created or change state
8. Run `pvc-explorer.yaml` to easily examine the contents of your PVC:
```bash
echo 'apiVersion: v1
kind: ReplicationController
metadata:
  name: pvc-explorer
  namespace: test
spec:
  replicas: 1
  selector:
    component: pvc-explorer
  template:
    metadata:
      labels:
        component: pvc-explorer
    spec:
      hostNetwork: true
      containers:
      - name: pvc-explorer
        imagePullPolicy: Always
        image: ubuntu:16.04
        stdin: true
        tty: true
        workingDir: "/pvc/"
        volumeMounts:
        - name: pvc
          mountPath: "/pvc/"
      volumes:
      - name: pvc
        persistentVolumeClaim:
          claimName: test-home' > pvc-explorer.yaml && kubectl create -f pvc-explorer.yaml
```
    * Performing an `ls -al`, you should see an AppData subdirectory. Drilling down into this directory, you should see a familiar MongoDB file structure