### PR TITLE
Check for error, not nil service

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1894,7 +1894,7 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 
 	// Create the controller template
 	account, _ := s.etcd.GetAccount(userId)
-        cfg := s.Config
+	cfg := s.Config
 	nodeSelectorName := cfg.Kubernetes.NodeSelectorName
 	nodeSelectorValue := cfg.Kubernetes.NodeSelectorValue
 	template := s.kube.CreateControllerTemplate(userId, name, stack.Id, s.domain, account.EmailAddress, s.email.Server, stackService, spec, addrPortMap, &extraVols, nodeSelectorName, nodeSelectorValue)
@@ -2137,8 +2137,8 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 	for _, stackService := range stackServices {
 		spec, _ := s.etcd.GetServiceSpec(userId, stackService.Service)
 		name := fmt.Sprintf("%s-%s", stack.Id, spec.Key)
-		svc, _ := s.kube.GetService(userId, name)
-		if svc != nil {
+		svc, err := s.kube.GetService(userId, name)
+		if err == nil {
 			addrPort := kube.ServiceAddrPort{
 				Name:     stackService.Service,
 				Host:     svc.Spec.ClusterIP,
@@ -2146,6 +2146,8 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 				NodePort: svc.Spec.Ports[0].NodePort,
 			}
 			addrPortMap[stackService.Service] = addrPort
+		} else {
+			glog.V(4).Infof("Error getting service %s: %s\n", name, err)
 		}
 	}
 


### PR DESCRIPTION
The go client returns empty objects on error, so current checks that look for nil objects fail.