### PR TITLE
Support finer grained security capabilities

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1146,7 +1146,7 @@ func (s *Server) PostService(w rest.ResponseWriter, r *rest.Request) {
 		glog.V(1).Infof("Added system service %s\n", service.Key)
 	} else {
 		// Don't allow privileged services in user catalogs
-		service.Privileged = false
+		service.SecurityContext = v1.SecurityContext{}
 
 		// Always require auth on user catalog services
 		service.AuthRequired = true
@@ -1223,7 +1223,7 @@ func (s *Server) PutService(w rest.ResponseWriter, r *rest.Request) {
 			return
 		}
 		// Don't allow privileged services in user catalogs
-		service.Privileged = false
+		service.SecurityContext = v1.SecurityContext{}
 
 		// Always require auth on user catalog services
 		service.AuthRequired = true

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -618,6 +618,7 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 	} else {
 		tag = "latest"
 	}
+
 	k8template := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -638,9 +639,7 @@ func (k *KubeHelper) CreateControllerTemplate(ns string, name string, stack stri
 					Command:         spec.Command,
 					Resources:       k8rq,
 					ImagePullPolicy: v1.PullAlways,
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &spec.Privileged,
-					},
+					SecurityContext: &spec.SecurityContext,
 				},
 			},
 			NodeSelector: map[string]string{

--- a/apiserver/pkg/types/types.go
+++ b/apiserver/pkg/types/types.go
@@ -1,6 +1,10 @@
 // Copyright ÃÂÃÂ© 2016 National Data Service
 package types
 
+import (
+        "k8s.io/api/core/v1"
+)
+
 type ServiceSpec struct {
 	Id                   string              `json:"id"`
 	Key                  string              `json:"key"`
@@ -26,7 +30,7 @@ type ServiceSpec struct {
 	DeveloperEnvironment string              `json:"developerEnvironment"`
 	Tags                 []string            `json:"tags"`
 	Info                 string              `json:"info"`
-	Privileged           bool                `json:"privileged"`
+	SecurityContext      v1.SecurityContext  `json:"securityContext"`
 	AuthRequired         bool                `json:"authRequired"`
 }
 

--- a/apiserver/test/services/test/full.json
+++ b/apiserver/test/services/test/full.json
@@ -8,6 +8,22 @@
 		"name": "ndslabs/cowsay",
 		"tags": ["latest", "v1", "v2", "v3"]
 	},
+        "securityContext": {
+		"allowPrivilegeEscalation": true,
+		"capabilities": {
+			"add": ["NET_ADMIN", "SYS_TIME"],
+			"drop": ["NET_ADMIN"]
+		},
+		"privileged": true,
+		"procMount": "UnmaskedProcMount",
+		"readOnlyRootFilesystem": true,
+		"runAsGroup": 1000,
+		"runAsNonRoot": true,
+		"runAsUser": 1000,
+		"seLinuxOptions": {
+			"level": "s0:c123,c456"
+		}
+	},
 	"display": "stack",
 	"access": "external",
 	"depends": [{


### PR DESCRIPTION
### Problem
We currently only have 2 levels of security: `default` and `privileged`. Since Kubernetes supports very fine-grained security features, we should support those individually.

Fixes #266 

### Approach
Replace `privileged` boolean on our Spec object with a `securityContext` field that can be passed directly through to Kubernetes.

NOTE: Since this is an admin-only field, there is no API validation or UI component to this PR.

### How to Test
1. `minikube start`
2. `docker run --name=etcd -p 4001:4001 -d ndslabs/etcd:2.2.5  /usr/local/bin/etcd \
         --bind-addr=0.0.0.0:4001 \
         --advertise-client-urls=http://127.0.0.1:4001`
3. Configure `apiserver.json` to point to minikube and etcd
4. Checkout, build branch locally, then run: `./build.sh local && ./build/bin/apiserver-darwin-amd64`
5. Use Postman to login as the admin, change log level to `4`, create a user, verify the email address, and approve the account
6. Use Postman to add the `full.json` spec to the catalog
7. Use Postman to create a stack from the `fulltest` spec
8. Use Postman to trigger StartStack on the stack you just created
9. Check the log output of the API server
    * You should see the full template of the stack that is being created
    * You should see `securityContext` listed under your `container` (not the pod itself)
10. Verify with `kubectl get pods -n <user> -o yaml`
    * You should see `securityContext` listed under your `container` (not the pod itself)

NOTE: On second thought, I should probably add a new set of Postman tests for the security