### PR TITLE
Speed up local apiserver builds with optional flag for fetching dependencies

### DIFF
--- a/apiserver/build.sh
+++ b/apiserver/build.sh
@@ -17,7 +17,13 @@ if [ "$1" == "local" ] || [ "$1" == "docker" ]; then
     echo "  BUILD_DATE = \"$BUILD_DATE\"" >> $VERSIONFILE
     echo ")" >> $VERSIONFILE
     
-    glide install --strip-vendor
+    # Check for --cache flag
+    args="$@"
+    replaced="${@/--cache/}"
+    if [ "$args" == "$replaced" ]; then
+        echo "Fetching dependencies..."
+        glide install --strip-vendor
+    fi
     
     COVERPKG=./cmd/server,./pkg/crypto,./pkg/etcd,./pkg/config,./pkg/email,./pkg/events,./pkg/kube,./pkg/middleware,./pkg/types,./pkg/validate
 	if [ "$1" == "local" ]; then 


### PR DESCRIPTION
### Problem
API server takes several minutes to build a one-line change. This is partially due to the fact that we always re-pull our vendor dependencies with `glide`, even if they have not changed.

### Approach
Add an optional `--cache` flag that will signal to skip pulling the vendor dependencies. This way, we can skip directly to building the binaries if we haven't added any new dependencies.

Note that by default (e.g. during DockerHub build), dependencies will be pulled

### How to Test
1. Checkout this branch locally
2. Change directories to `ndslabs/apiserver/`
3. Execute `./build.sh local`
    * You should see `Fetching dependencies...`, followed by the usual `glide` fetch output
4. Now execute `./build.sh local --cache`
    * You should immediately see `Building apiserver-darwin-amd64` with no reference to fetching dependencies