### PR TITLE
Added QPS and Burst overrides

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -95,6 +95,12 @@ func main() {
 	if cfg.Kubernetes.TokenPath == "" {
 		cfg.Kubernetes.TokenPath = "/run/secrets/kubernetes.io/serviceaccount/token"
 	}
+	if cfg.Kubernetes.QPS <= 0 {
+		cfg.Kubernetes.QPS = 50
+	}
+	if cfg.Kubernetes.Burst <= 0 {
+		cfg.Kubernetes.Burst = 100
+	}
 	if cfg.DefaultLimits.MemMax <= 0 {
 		cfg.DefaultLimits.MemMax = 8196 //M
 	}
@@ -143,6 +149,9 @@ func main() {
 			panic(err.Error())
 		}
 	}
+
+	kConfig.QPS = cfg.Kubernetes.QPS
+	kConfig.Burst = cfg.Kubernetes.Burst
 
 	kube, err := kube.NewKubeHelper(cfg.Kubernetes.Address,
 		cfg.Kubernetes.Username, cfg.Kubernetes.Password, cfg.Kubernetes.TokenPath, kConfig, cfg.AuthSignInURL, cfg.AuthURL)

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -33,9 +33,9 @@ type Specs struct {
 	Path string `json:"path"`
 }
 type Volume struct {
-	Path     string     `json:"path"`
-	Name     string     `json:"name"`
-	ReadOnly bool       `json:"readOnly"`
+	Path     string `json:"path"`
+	Name     string `json:"name"`
+	ReadOnly bool   `json:"readOnly"`
 }
 
 type DefaultLimits struct {
@@ -51,13 +51,15 @@ type Etcd struct {
 	MaxMessages int    `json:"maxMessages"`
 }
 type Kubernetes struct {
-	Address            string `json:"address"`
-	TokenPath          string `json:"tokenPath"`
-	Username           string `json:"username"`
-	Password           string `json:"password"`
-	NodeSelectorName   string `json:"nodeSelectorName"`
-	NodeSelectorValue  string `json:"nodeSelectorValue"`
-	StorageClass       string `json:"pvcStorageClass"`
+	Address           string  `json:"address"`
+	TokenPath         string  `json:"tokenPath"`
+	Username          string  `json:"username"`
+	Password          string  `json:"password"`
+	NodeSelectorName  string  `json:"nodeSelectorName"`
+	NodeSelectorValue string  `json:"nodeSelectorValue"`
+	StorageClass      string  `json:"pvcStorageClass"`
+	QPS               float32 `json:"qps"`
+	Burst             int     `json:"burst"`
 }
 type Email struct {
 	Host string `json:"host"`


### PR DESCRIPTION
Fixes #289 

This adds the QPS and Burst configuration overrides for the kube client. I've set defaults at 50/100, which works for the CHEESEHub case.

To test:
* Deploy this apiserver
* Run the https://github.com/cheese-hub/loadtest