### PR TITLE
Analytics event tracking

### DIFF
--- a/gui/dashboard/catalog/CatalogController.js
+++ b/gui/dashboard/catalog/CatalogController.js
@@ -22,9 +22,9 @@ angular
  * @author lambert8
  * @see https://opensource.ncsa.illinois.edu/confluence/display/~lambert8/3.%29+Controllers%2C+Scopes%2C+and+Partial+Views
  */
-.controller('CatalogController', [ '$scope', '$filter', '$interval', '$uibModal', '$location', '$log', '_', 'NdsLabsApi', 'Project', 'Stack', 'Stacks', 
+.controller('CatalogController', [ '$scope', '$filter', '$interval', '$uibModal', '$location', '$log', '_', 'Analytics', 'NdsLabsApi', 'Project', 'Stack', 'Stacks', 
     'StackService', 'Specs', 'clipboard', 'Vocabulary', 'RandomPassword', 'AuthInfo', 'ProductName', 'ApiUri', 'DashboardAppPath', 'HomePathSuffix',
-    function($scope, $filter, $interval, $uibModal, $location, $log, _, NdsLabsApi, Project, Stack, Stacks, StackService, Specs, clipboard, Vocabulary, RandomPassword, AuthInfo, ProductName, ApiUri, DashboardAppPath, HomePathSuffix) {
+    function($scope, $filter, $interval, $uibModal, $location, $log, _, Analytics, NdsLabsApi, Project, Stack, Stacks, StackService, Specs, clipboard, Vocabulary, RandomPassword, AuthInfo, ProductName, ApiUri, DashboardAppPath, HomePathSuffix) {
   "use strict";
   
   $scope.productName = ProductName;
@@ -145,6 +145,7 @@ angular
     var quickstartUrl = getQuickStartUrl(spec);
     console.log("Copying to clipboard:", quickstartUrl);
     clipboard.copyText(quickstartUrl);
+    Analytics.trackEvent('application', 'share-url', spec.key, 1, true);
   };
   
   $scope.shareEmbed = function(spec) {
@@ -157,6 +158,7 @@ angular
     var htmlString = '<a href="' + quickstartUrl + '">Try ' + spec.label + '</a>';
     console.log("Copying to clipboard:", htmlString);
     clipboard.copyText(htmlString);
+    Analytics.trackEvent('application', 'share-embed', spec.key, 1, true);
   };
   
   $scope.cloneSpec = function(spec) {
@@ -250,6 +252,8 @@ angular
     // Install this app to etcd
     return NdsLabsApi.postStacks({ 'stack': app }).then(function(stack, xhr) {
       $log.debug("successfully posted to /projects/" + projectId + "/stacks!");
+
+      Analytics.trackEvent('application', 'add', spec.key, 1, true);
       
       // Add /the new stack to the UI
       Stacks.all.push(stack);

--- a/gui/dashboard/dashboard/DashboardController.js
+++ b/gui/dashboard/dashboard/DashboardController.js
@@ -168,7 +168,7 @@ angular
    * @param {} service - the service to show logs for
    */ 
   $scope.showLogs = function(service) {
-    Analytics.trackEvent('application', 'logs', service.key, 1, true);
+    Analytics.trackEvent('application', 'logs', service.service, 1, true);
 
     // See 'app/dashboard/modals/logViewer/logViewer.html'
     $uibModal.open({
@@ -190,7 +190,7 @@ angular
    * @param {} service - the service to show logs for
    */ 
   $scope.showConfig = function(service) {
-    Analytics.trackEvent('application', 'config', service.key, 1, true);
+    Analytics.trackEvent('application', 'config', service.service, 1, true);
 
     // See 'app/dashboard/modals/logViewer/logViewer.html'
     $uibModal.open({

--- a/gui/dashboard/dashboard/DashboardController.js
+++ b/gui/dashboard/dashboard/DashboardController.js
@@ -9,9 +9,9 @@ angular
  * @author lambert8
  * @see https://opensource.ncsa.illinois.edu/confluence/display/~lambert8/3.%29+Controllers%2C+Scopes%2C+and+Partial+Views
  */
-.controller('DashboardController', [ '$scope', 'Loading', '$log', '$routeParams', '$location', '$interval', '$q', '$window', '$filter', '$uibModal', '_', 'Project', 'RandomPassword', 'Stack', 'Stacks', 'Specs', 'AutoRefresh', 'AuthInfo',
+.controller('DashboardController', [ '$scope', 'Loading', '$log', '$routeParams', '$location', '$interval', '$q', '$window', '$filter', '$uibModal', '_', 'Analytics', 'Project', 'RandomPassword', 'Stack', 'Stacks', 'Specs', 'AutoRefresh', 'AuthInfo',
       'StackService', 'NdsLabsApi', 'ProductName', 'FileManager', 'QuickStart',
-    function($scope, Loading, $log, $routeParams, $location, $interval, $q, $window, $filter, $uibModal, _, Project, RandomPassword, Stack, Stacks, Specs, AutoRefresh, AuthInfo, StackService, NdsLabsApi,
+    function($scope, Loading, $log, $routeParams, $location, $interval, $q, $window, $filter, $uibModal, _, Analytics, Project, RandomPassword, Stack, Stacks, Specs, AutoRefresh, AuthInfo, StackService, NdsLabsApi,
       ProductName, FileManager, QuickStart) {
   "use strict";
   
@@ -79,6 +79,7 @@ angular
       'stackId': stack.id
     }).then(function(data, xhr) {
       $log.debug('successfully started ' + stack.name);
+      Analytics.trackEvent('application', 'launch', stack.key, 1, true);
     }, function(headers) {
       $log.error('failed to start ' + stack.name);
     }).finally(function() {
@@ -129,6 +130,7 @@ angular
         'stackId': stack.id
       }).then(function(data, xhr) {
         $log.debug('successfully stopped ' + stack.name);
+        Analytics.trackEvent('application', 'shutdown', stack.key, 1, true);
       }, function(headers) {
         $log.error('failed to stop ' + stack.name);
       })
@@ -166,6 +168,8 @@ angular
    * @param {} service - the service to show logs for
    */ 
   $scope.showLogs = function(service) {
+    Analytics.trackEvent('application', 'logs', service.key, 1, true);
+
     // See 'app/dashboard/modals/logViewer/logViewer.html'
     $uibModal.open({
       animation: true,
@@ -186,6 +190,8 @@ angular
    * @param {} service - the service to show logs for
    */ 
   $scope.showConfig = function(service) {
+    Analytics.trackEvent('application', 'config', service.key, 1, true);
+
     // See 'app/dashboard/modals/logViewer/logViewer.html'
     $uibModal.open({
       animation: true,
@@ -248,6 +254,8 @@ angular
         'stackId': stack.id
       }).then(function(data, xhr) {
         $log.debug('successfully deleted stack: ' + stack.name);
+        Analytics.trackEvent('application', 'delete', stack.key, 1, true);
+
         Loading.set(Stacks.populate());
       }, function(headers) {
         $log.error('failed to delete stack: ' + stack.name);

--- a/gui/dashboard/dashboard/dashboard.html
+++ b/gui/dashboard/dashboard/dashboard.html
@@ -118,6 +118,7 @@
                           {{ svc.service | specProperty:'label' }}
                           <a  ng-repeat="endpt in svc.endpoints track by endpt.port" id="endpointLink"
                               uib-tooltip="Navigate to {{ svc.service | capitalize }} port {{ endpt.port }}"
+                              ga-event-track="['application', 'endpoint', svc.key]"
                               ng-if="stack.status === 'started' && svc.status === 'ready' 
                                   && endpt !== '' && ((stack.key | specProperty:'access') === 'external') && (endpt.protocol === 'http')"  target="_blank"
                               ng-href="{{ endpt | externalHostPort }}"
@@ -132,6 +133,7 @@
                         <!-- Console -->
                         <td class="text-center">
                           <a  id="consoleBtn"
+                              ga-track-event="['application', 'console', svc.service, 1, true]"
                               type="button" class="btn btn-default btn-xs" target="_blank" ng-href="/dashboard/home/{{ stack.id }}/console/{{ svc.service }}"
                               ng-disabled="svc.status !== 'ready'">
                             <i class="fa fa-terminal"></i>
@@ -142,7 +144,7 @@
                         <td class="text-center">
                           <!-- ng-click="showConfig(svc)" -->
                           <a  id="editServiceBtn" type="button" class="btn btn-default btn-xs" ng-href="/dashboard/home/{{ stack.id }}/edit/{{ svc.service }}"
-                              ng-if="stack.status === 'stopped'">
+                              ng-if="stack.status === 'stopped'" ga-track-event="['application', 'edit', svc.service, 1, true]">
                             <i class="fa fa-wrench"></i>
                           </a>
                           
@@ -172,7 +174,7 @@
                         </td>
                         
                         <!-- Help Link -->
-                        <td class="text-center"><a  id="helpLink" ng-if="svc.service | specProperty:'info'" ng-href="{{ svc.service | specProperty:'info' }}" target="_blank"><i class="fa fa-fw fa-question-circle"></i></a></td>
+                        <td class="text-center"><a  id="helpLink" ng-if="svc.service | specProperty:'info'" ng-href="{{ svc.service | specProperty:'info' }}" target="_blank" ga-track-event="['application', 'help', svc.service, 1, true]"><i class="fa fa-fw fa-question-circle"></i></a></td>
                       </tr>
                       
                       <!-- Add an artificial row (if necessary) for optional services -->


### PR DESCRIPTION
## Problem
We currently have no way of tracking user actions within the system. That is, given a set of users exercising the system, we are unable to track history of which applications were run or which actions were performed.

Moreover we have no way of knowing when users are encountering issues with a particular application.

Fixes #294 

## Approach
Add simple event tracking to monitor which buttons the user pushes on the Workbench Dashboard. 

We can now track:
* page views (present previously)
* adding an application from the catalog
* deleting your instance of an application
* starting / stopping an application
* viewing logs/config/console for an application's service
* editing an application's service

NOTE: If we can think of other low-hanging analytics to track here, I am open to further suggestions :+1:

## How to Test
* Prerequisites: 
    * Disable Adblock / uBlock for `https://www.local.ndslabs.org/dashboard`
    * Configure Google Analytics with the tracking ID for CHEESEhub Dev (`UA-156933757-2`)
    * Open the Google Analytics Dashboard and view CHEESEhub Dev > Realtime > Events

1. Checkout and deploy this branch locally
2. Login to the Workbench Dashboard
3. Navigate to the Catalog view
4. Click `Add` to create an instance of an application from the Catalog
    * You should see an `add` Event appear in the GA Dashboard with the `spec.key` and a counter of how many times it was clicked
    * You should see the "View" button appear alongside "Add"
5. Click `View`
    * You should be brought to the Applications Dashboard
6. Expand your new application and click `Edit`, then go back
    * You should see an `edit` Event appear in the GA Dashboard with the `svc.service` and a counter of how many times it was clicked
    * You should be brought to the "Edit Stack Service" view
7. Expand your application and click `Launch` 
    * You should see a `launch` Event appear in the GA Dashboard with the `stack.key` and a counter of how many times it was clicked
    * Your application should begin to start
8. Expand your application and click `Config`
    * You should see a `config` Event appear in the GA Dashboard with the `svc.service` and a counter of how many times it was clicked
    * You should be shown the config modal
9. Expand your application and click `Logs`
    * You should see a `logs` Event appear in the GA Dashboard with the `svc.service` and a counter of how many times it was clicked
    * You should be shown the logs modal
9. Expand your application and click `Console`, then go back
    * You should see a `console` Event appear in the GA Dashboard with the `svc.service` and a counter of how many times it was clicked
    * You should be brought to the "Application Service Console" view
10. Wait for the application to finish launching, then expand your application and click `Shutdown` 
    * You should see a `shutdown` Event appear in the GA Dashboard with the `stack.key` and a counter of how many times it was clicked
    * Your application should start to spin down
11. Wait for the application to finish shutting down, then expand your application and click `Remove` 
    * You should see a `delete` Event appear in the GA Dashboard with the `stack.key` and a counter of how many times it was clicked
    * Your application should be removed from the view