### PR TITLE
Hide advanced features behind config flags

### DIFF
--- a/gui/ConfigModule.js
+++ b/gui/ConfigModule.js
@@ -17,6 +17,20 @@ angular
  * Make lodash available for injection into controllers
  */
 .constant('_', window._)
+
+/**
+ * Toggles for hiding the more advanced UI features
+ */
+.constant('AdvancedFeatures', {
+    showConsole: false,
+    showEditService: false,
+    showRemoveService: false,
+    showCreateSpec: false,
+    showImportSpec: false,
+    showFileManager: false,
+    showServiceHelpIcon: false,
+})
+
 /**
  * The back-up (default) administrator e-mail to use for support, 
  * in case the /api/contact endpoint is unavailable

--- a/gui/ConfigModule.js
+++ b/gui/ConfigModule.js
@@ -60,7 +60,7 @@ angular
 .constant('EditSpecPathSuffix', '/store/edit/:specKey/')
 
 // Navigate here when clicking "Sign In"
-.constant('SigninUrl', 'https://www.local.ndslabs.org/oauth2/authorize')
+.constant('SigninUrl', 'https://www.local.ndslabs.org/login/')
 
 /**
  * The name of the product to display in the UI and the URL to link to when clicked

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -30,6 +30,11 @@ ENV APISERVER_HOST="localhost" \
     APISERVER_PATH="/api" \
     APISERVER_SECURE="true" \
     ANALYTICS_ACCOUNT="" \
+    SHOW_CONSOLE="false" \
+    SHOW_IMPORT_SPEC="false" \
+    SHOW_CREATE_SPEC="false" \
+    SHOW_FILE_MANAGER="false" \
+    SHOW_EDIT_SERVICE="false" \
     SUPPORT_EMAIL="ndslabs-support@nationaldataservice.org"
 
 # Expose port 3000 for ExpressJS

--- a/gui/dashboard/catalog/CatalogController.js
+++ b/gui/dashboard/catalog/CatalogController.js
@@ -23,10 +23,12 @@ angular
  * @see https://opensource.ncsa.illinois.edu/confluence/display/~lambert8/3.%29+Controllers%2C+Scopes%2C+and+Partial+Views
  */
 .controller('CatalogController', [ '$scope', '$filter', '$interval', '$uibModal', '$location', '$log', '_', 'NdsLabsApi', 'Project', 'Stack', 'Stacks', 
-    'StackService', 'Specs', 'clipboard', 'Vocabulary', 'RandomPassword', 'AuthInfo', 'ProductName', 'ApiUri', 'DashboardAppPath', 'HomePathSuffix',
-    function($scope, $filter, $interval, $uibModal, $location, $log, _, NdsLabsApi, Project, Stack, Stacks, StackService, Specs, clipboard, Vocabulary, RandomPassword, AuthInfo, ProductName, ApiUri, DashboardAppPath, HomePathSuffix) {
+    'StackService', 'Specs', 'clipboard', 'Vocabulary', 'RandomPassword', 'AuthInfo', 'ProductName', 'ApiUri', 'DashboardAppPath', 'HomePathSuffix', 'AdvancedFeatures',
+    function($scope, $filter, $interval, $uibModal, $location, $log, _, NdsLabsApi, Project, Stack, Stacks, StackService, Specs, clipboard, Vocabulary, RandomPassword, AuthInfo, ProductName, ApiUri, DashboardAppPath, HomePathSuffix, AdvancedFeatures) {
   "use strict";
   
+  $scope.showCreateSpec = AdvancedFeatures.showCreateSpec;
+  $scope.showImportSpec = AdvancedFeatures.showImportSpec;
   $scope.productName = ProductName;
       
   $scope.tags = { all: [], selected: [] };

--- a/gui/dashboard/catalog/catalog.html
+++ b/gui/dashboard/catalog/catalog.html
@@ -34,11 +34,11 @@
           </button>
         </div>
         <div class="input-group-btn">
-          <button id="importApplicationBtn" type="button" class="btn btn-secondary" ng-click="openImport()" style="border-radius:0;">
+          <button id="importApplicationBtn" ng-if="showImportSpec" type="button" class="btn btn-secondary" ng-click="openImport()" style="border-radius:0;">
             <i class="fa fa-fw fa-upload"></i> Import
           </button>
         </div>
-        <div class="input-group-btn">
+        <div class="input-group-btn" ng-if="showCreateSpec">
           <a id="createApplicationBtn" type="button" class="btn btn-primary" href="/dashboard/store/add">
             <i class="fa fa-fw fa-plus"></i> Create
           </a>

--- a/gui/dashboard/dashboard/DashboardController.js
+++ b/gui/dashboard/dashboard/DashboardController.js
@@ -10,15 +10,19 @@ angular
  * @see https://opensource.ncsa.illinois.edu/confluence/display/~lambert8/3.%29+Controllers%2C+Scopes%2C+and+Partial+Views
  */
 .controller('DashboardController', [ '$scope', 'Loading', '$log', '$routeParams', '$location', '$interval', '$q', '$window', '$filter', '$uibModal', '_', 'Project', 'RandomPassword', 'Stack', 'Stacks', 'Specs', 'AutoRefresh', 'AuthInfo',
-      'StackService', 'NdsLabsApi', 'ProductName', 'FileManager', 'QuickStart',
+      'StackService', 'NdsLabsApi', 'ProductName', 'FileManager', 'QuickStart', 'AdvancedFeatures',
     function($scope, Loading, $log, $routeParams, $location, $interval, $q, $window, $filter, $uibModal, _, Project, RandomPassword, Stack, Stacks, Specs, AutoRefresh, AuthInfo, StackService, NdsLabsApi,
-      ProductName, FileManager, QuickStart) {
+      ProductName, FileManager, QuickStart, AdvancedFeatures) {
   "use strict";
   
   if ($routeParams.quickstart) {
     QuickStart.get($routeParams.quickstart).launch();
   }
   
+  $scope.showRemoveService = AdvancedFeatures.showRemoveService;
+  $scope.showServiceHelpIcon = AdvancedFeatures.showServiceHelpIcon;
+  $scope.showEditService = AdvancedFeatures.showEditService;
+  $scope.showConsole = AdvancedFeatures.showConsole;
   $scope.fileManager = FileManager;
   
   $scope.productName = ProductName;

--- a/gui/dashboard/dashboard/dashboard.html
+++ b/gui/dashboard/dashboard/dashboard.html
@@ -83,18 +83,14 @@
                     <thead>
                       <tr>
                         <td width="15%" class="text-center"><strong>Status</strong></td>
-                        <td width="20%"><strong>Name</strong></td>
-                        <td width="20%"><strong>ID</strong></td>
-                        <td width="10%" class="text-center"><strong>Console</strong></td>
-                        <td width="10%" class="text-center">
-                          <strong ng-if="stack.status !== 'stopped'">Config</strong>
-                          <strong ng-if="stack.status === 'stopped'">Edit</strong>
-                        </td>
-                        <td width="10%" class="text-center">
-                          <strong ng-if="stack.status !== 'stopped'">Logs</strong>
-                          <strong ng-if="stack.status === 'stopped'">Remove</strong>
-                        </td>
-                        <td width="10%" class="text-center"><strong>Help</strong></td>
+                        <td><strong>Name</strong></td>
+                        <td><strong>ID</strong></td>
+                        <td width="5%" class="text-center" ng-if="showConsole"><strong>Console</strong></td>
+                        <td width="5%" class="text-center" ng-if="showEditService && stack.status === 'stopped'"><strong>Edit</strong></td>
+                        <td width="5%" class="text-center" ng-if="stack.status !== 'stopped'"><strong >Config</strong></td>
+                        <td width="5%" class="text-center" ng-if="stack.status !== 'stopped'"><strong >Logs</strong></td>
+                        <td width="5%" class="text-center" ng-if="showRemoveService && stack.status === 'stopped'"><strong>Remove</strong></td>
+                        <td width="5%" class="text-center" ng-if="showServiceHelpIcon"><strong>Help</strong></td>
                       </tr>
                     </thead>
                     <tbody>
@@ -130,22 +126,24 @@
                         <td><span id="serviceIdText">{{ svc.id }}</span></td>
                         
                         <!-- Console -->
-                        <td class="text-center">
+                        <td class="text-center" ng-if="showConsole">
                           <a  id="consoleBtn"
                               type="button" class="btn btn-default btn-xs" target="_blank" ng-href="/dashboard/home/{{ stack.id }}/console/{{ svc.service }}"
                               ng-disabled="svc.status !== 'ready'">
                             <i class="fa fa-terminal"></i>
                           </a>
                         </td>
-                        
-                        <!-- View/Edit Config buttons -->
-                        <td class="text-center">
+
+                        <td class="text-center" ng-if="showEditService">
                           <!-- ng-click="showConfig(svc)" -->
                           <a  id="editServiceBtn" type="button" class="btn btn-default btn-xs" ng-href="/dashboard/home/{{ stack.id }}/edit/{{ svc.service }}"
                               ng-if="stack.status === 'stopped'">
                             <i class="fa fa-wrench"></i>
                           </a>
-                          
+                          </td>
+                        
+                        <!-- View/Edit Config buttons -->
+                        <td class="text-center">
                           <button id="viewConfigBtn" type="button" class="btn btn-default btn-xs" ng-click="showConfig(svc)"
                               ng-if="stack.status !== 'stopped' && (!_.isEmpty(svc.config) || svc.endpoints.length > 0)">
                             <i class="fa fa-puzzle-piece"></i>
@@ -162,7 +160,10 @@
                             <i class="fa fa-fw fa-file-text" ng-class="{ 'animated faa-vertical': stack.status === 'starting' && (svc.status === 'waiting' || svc.status === 'starting') }"></i>
                           </button>
                           
-                          <!-- Remove service from stack button -->
+                        </td>
+
+                        <!-- Remove optional service from stack -->
+                        <td class="text-center" ng-if="showRemoveService && stack.status === 'stopped'">
                           <button type="button" ng-disabled="stack.services | isRecursivelyRequired:svc"  id="removeBtn" 
                               ng-if="stack.status === 'stopped' && svc.service !== stack.key && !_.find((stack.key | requirements), [ 'key', svc.service ])" 
                               class="btn btn-xs btn-default" ng-click="removeStackSvc(stack, svc)" 
@@ -172,7 +173,7 @@
                         </td>
                         
                         <!-- Help Link -->
-                        <td class="text-center"><a  id="helpLink" ng-if="svc.service | specProperty:'info'" ng-href="{{ svc.service | specProperty:'info' }}" target="_blank"><i class="fa fa-fw fa-question-circle"></i></a></td>
+                        <td class="text-center" ng-if="showServiceHelpIcon"><a  id="helpLink" ng-if="svc.service | specProperty:'info'" ng-href="{{ svc.service | specProperty:'info' }}" target="_blank"><i class="fa fa-fw fa-question-circle"></i></a></td>
                       </tr>
                       
                       <!-- Add an artificial row (if necessary) for optional services -->
@@ -194,7 +195,7 @@
                         
                         <td colspan="4">{{ stack.selectedOption | specProperty:'description' }}</td>
                         
-                        <td class="text-center">
+                        <td class="text-center" ng-if="showServiceHelpIcon">
                           <a id="addServiceHelpLink" ng-if="stack.selectedOption | specProperty:'info'" ng-href="{{ stack.selectedOption | specProperty:'info' }}" target="_blank">
                             <i class="fa fa-fw fa-question-circle"></i>
                           </a>

--- a/gui/entrypoint.sh
+++ b/gui/entrypoint.sh
@@ -16,5 +16,16 @@
 # Substitute the ANALYTICS_ACCOUNT passed in by "docker run -e" or kubernetes
 /bin/sed -i -e "s#^\.constant('GaAccount', .*)#.constant('GaAccount', '${ANALYTICS_ACCOUNT}')#" "$BASEDIR/ConfigModule.js"
 
+# In lieu of actual user management, some instance-wide flags to toggle the more advanced features
+/bin/sed -i -e "s#^\showConsole: .*,#showConsole: ${SHOW_CONSOLE:-false},#" "$BASEDIR/ConfigModule.js"
+/bin/sed -i -e "s#^\showEditService: .*,#showEditService: ${SHOW_EDIT_SERVICE:-false},#" "$BASEDIR/ConfigModule.js"
+/bin/sed -i -e "s#^\showRemoveService: .*,#showRemoveService: ${SHOW_REMOVE_SERVICE:-false},#" "$BASEDIR/ConfigModule.js"
+/bin/sed -i -e "s#^\showServiceHelpIcon: .*,#showServiceHelpIcon: ${SHOW_SERVICE_HELP_ICON:-false},#" "$BASEDIR/ConfigModule.js"
+/bin/sed -i -e "s#^\showCreateSpec: .*,#showCreateSpec: ${SHOW_CREATE_SPEC:-false},#" "$BASEDIR/ConfigModule.js"
+/bin/sed -i -e "s#^\showImportSpec: .*,#showImportSpec: ${SHOW_IMPORT_SPEC:-false},#" "$BASEDIR/ConfigModule.js"
+/bin/sed -i -e "s#^\showFileManager: .*,#showFileManager: ${SHOW_FILE_MANAGER:-false},#" "$BASEDIR/ConfigModule.js"
+
+/bin/sed -i -e "s#^\.constant('AllowDuplicateApps', .*)#.constant('AllowDuplicateApps', ${ALLOW_DUPLICATE_APPS:-false})#" "$BASEDIR/ConfigModule.js"
+
 # Start ExpressJS
 node server.js

--- a/gui/shared/navbar/NavbarController.js
+++ b/gui/shared/navbar/NavbarController.js
@@ -29,8 +29,8 @@ angular
  * @author lambert8
  * @see https://opensource.ncsa.illinois.edu/confluence/display/~lambert8/3.%29+Controllers%2C+Scopes%2C+and+Partial+Views
  */
-.controller('NavbarController', [ '$scope', '$rootScope', '$window', '$location', '$cookies', 'Project', 'AuthInfo', 'ProductName', 'ProductUrl', 'HelpLinks', 'FileManager', 'AutoRefresh', 'ReturnRoute', 'CookieOptions', 'SigninUrl',
-    function($scope, $rootScope, $window, $location, $cookies, Project, AuthInfo, ProductName, ProductUrl, HelpLinks, FileManager, AutoRefresh, ReturnRoute, CookieOptions, SigninUrl) {
+.controller('NavbarController', [ '$scope', '$rootScope', '$window', '$location', '$cookies', 'Project', 'AuthInfo', 'ProductName', 'ProductUrl', 'HelpLinks', 'FileManager', 'AutoRefresh', 'ReturnRoute', 'CookieOptions', 'SigninUrl', 'AdvancedFeatures',
+    function($scope, $rootScope, $window, $location, $cookies, Project, AuthInfo, ProductName, ProductUrl, HelpLinks, FileManager, AutoRefresh, ReturnRoute, CookieOptions, SigninUrl, AdvancedFeatures) {
   "use strict"
   
   // Enable JS dropdowns on the navbar
@@ -59,6 +59,7 @@ angular
   $scope.signinLink = $scope.enableOAuth ? SigninUrl : '/login/' + ($rootScope.rd ? 'rd=' : '');
   $scope.helpLinks = HelpLinks;
   
+  $scope.showFileManager = AdvancedFeatures.showFileManager;
   $scope.fileManager = FileManager;
   $scope.launchingFileManager = FileManager.busy;
   $scope.$watch('fileManager.busy', function(newValue, oldValue) {

--- a/gui/shared/navbar/navbar.html
+++ b/gui/shared/navbar/navbar.html
@@ -30,7 +30,7 @@
           </li>
           
 	        <!-- Then draw our Manage Files button -->
-          <li>
+          <li ng-if="showFileManager">
             <a id="filesNav" type="button" ng-click="fileManager.launch()">
                <i class="fa fa-fw" ng-class="{ 'fa-spinner fa-pulse': launchingFileManager, 'fa-files-o': !launchingFileManager }"></i> Files
             </a>


### PR DESCRIPTION
* Hide advanced features behind configuration flags
    * `showConsole` (dashboard)
    * `showEditService` (dashboard)
    * `showRemoveService` (dashboard)
    * `showServiceHelpIcon` (dashboard)
    * `showCreateSpec` (catalog)
    * `showImportSpec` (catalog)
    * `showFileManager` (navbar)
* Add handling for enabling/disabling via environment variables

Fixes #304
Fixes #305 

Related to #311 #310 #309 