### PR TITLE
Hide Terms & Conditions link on signup if no 'Acceptable Use Policy' li…

### DIFF
--- a/gui/login/static/signUp/signUp.html
+++ b/gui/login/static/signUp/signUp.html
@@ -192,8 +192,8 @@
         </div>
       </div>
       
-      <!-- Link to Acceptable Use Policy -->
-      <div class="row">
+      <!-- Link to Acceptable Use Policy, if provided -->
+      <div class="row" ng-if="eulaLink && eulaLink.url">
         <div class="text-center col-sm-offset-3 col-sm-6" style="margin-bottom:10px;">
           By submitting this form you agree to our <a ng-href="{{ eulaLink.url }}" target="_blank" id="usePolicyLink">{{ eulaLink.name | lowercase }}</a>.
         </div>


### PR DESCRIPTION
## Problem
When no "Acceptable Use Policy" is provided, the Sign Up view is unaware and still lets the user know that they are agreeing to an empty link.

Fixes https://github.com/cheese-hub/cheesehub/issues/44

## Approach
Hide this line of text when no "Acceptable Use Policy" link is provided.