### PR TITLE
Support cert-manager, fix apiserver build dependencies

### DIFF
--- a/apiserver/.dockerignore
+++ b/apiserver/.dockerignore
@@ -1,5 +1,10 @@
-*/build
-*/vendor/github.com
-*/vendor/golang.org
-*/vendor/gopkg.in
-*/vendor/k8s.io
+*/build/*
+**/vendor/*
+
+.dockerignore
+.gitignore
+Dockerfile*
+*.sh
+apiserver.json
+!entrypoint.sh
+!build.sh

--- a/apiserver/.gitignore
+++ b/apiserver/.gitignore
@@ -1,0 +1,1 @@
+pkg/version/version.go

--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,25 +1,42 @@
-FROM golang:1.12-stretch as gobuild
-COPY . /go/src/github.com/ndslabs/apiserver
+# Create build time container
+FROM golang:1.15-buster as gobuild
 
-RUN apt-get -qq update && \
-    apt-get -qq install bash build-essential git gcc  && \
-    go get github.com/Masterminds/glide  &&  \
-    go get github.com/docker/spdystream  &&  \
-    cd /go/src/github.com/ndslabs/apiserver && ./build.sh docker
+# TODO: Is this needed?
+#ENV GOROOT=/usr/local/go \
+#    GOPATH=$HOME/go \
+#    PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
-FROM debian:stretch
-COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-linux-amd64 /ndslabsctl/ndslabsctl-linux-amd64
-COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-darwin-amd64 /ndslabsctl/ndslabsctl-darwin-amd64
-COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/apiserver-linux-amd64 /usr/local/bin/apiserver
-COPY entrypoint.sh /entrypoint.sh
-COPY templates /templates
+# Install build dependencies
 RUN apt-get -qq update && \
-    apt-get -qq install bash binutils git vim && \
+    apt-get -qq install --no-install-recommends build-essential git && \
+    go get github.com/Masterminds/glide && \
+    go get github.com/docker/spdystream
+
+# Install Glide dependencies
+WORKDIR /go/src/github.com/ndslabs/apiserver
+COPY glide.* ./
+RUN glide install --strip-vendor
+
+# Build golang code
+COPY . ./
+RUN ./build.sh docker
+
+# Create runtime container
+FROM debian:buster
+
+# Install runtime dependencies
+RUN apt-get -qq update && \
+    apt-get -qq install --no-install-recommends binutils git ca-certificates netcat && \
     apt-get -qq autoremove && \
     apt-get -qq autoclean && \
     apt-get -qq clean all && \
-    rm -rf /var/cache/apk/* /tmp/* /var/lib/apt/lists/* && \
-    ln -s /ndslabsctl/ndslabsctl-linux-amd64 /usr/local/bin/ndslabsctl 
+    rm -rf /var/cache/apk/* /tmp/* /var/lib/apt/lists/*
+
+# Copy final binaries from build container
+COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-*-amd64 /ndslabsctl/
+COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/apiserver-linux-amd64 /usr/local/bin/apiserver
+
+COPY entrypoint.sh templates /
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apiserver"]

--- a/apiserver/apiserver.json
+++ b/apiserver/apiserver.json
@@ -28,6 +28,10 @@
         "port": 0,
         "tls": true
     },
+    "certmgr": {
+        "clusterIssuer": "acmedns-issuer",
+        "issuer": ""
+    },
     "specs": {
         "path": "/path/to/ndslabs-specs"
     },

--- a/apiserver/build.sh
+++ b/apiserver/build.sh
@@ -20,7 +20,7 @@ if [ "$1" == "local" ] || [ "$1" == "docker" ]; then
     # Check for --cache flag
     args="$@"
     replaced="${@/--cache/}"
-    if [ "$args" == "$replaced" ]; then
+    if [ "$1" == "local" ] && [ "$args" == "$replaced" ]; then
         echo "Fetching dependencies..."
         glide install --strip-vendor
     fi

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -183,8 +183,9 @@ func main() {
 	server.homePvcSuffix = cfg.HomePvcSuffix
 	server.requireApproval = cfg.RequireApproval
 
+	glog.Info("Checking for TLS issuer...\n")
 	if cfg.Certmgr.ClusterIssuer != "" {
-		glog.Infof("Using TLS clsuter issuer: %s\n", cfg.Certmgr.ClusterIssuer)
+		glog.Infof("Using TLS cluster issuer: %s\n", cfg.Certmgr.ClusterIssuer)
 	} else if cfg.Certmgr.Issuer != "" {
 		glog.Infof("Using TLS issuer: %s\n", cfg.Certmgr.Issuer)
 	}

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1613,9 +1613,9 @@ func (s *Server) createIngressRule(userId string, svc *v1.Service, stack *api.St
 		return err
 	}
 	glog.V(4).Infof("Started ingress for service %s (secure=%t)\n", svc.Name, stack.Secure)
-        if cfg.Certmgr.ClusterIssuer != "" {
+        if clusterIssuer != "" {
                 glog.Infof("Using TLS clsuter issuer: %s\n", clusterIssuer)
-        } else if cfg.Certmgr.Issuer != "" {
+        } else if issuer != "" {
                 glog.Infof("Using TLS issuer: %s\n", issuer)
         }
 	return nil

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -1592,13 +1592,15 @@ func (s *Server) createKubernetesService(userId string, stack *api.Stack, spec *
 }
 
 func (s *Server) createIngressRule(userId string, svc *v1.Service, stack *api.Stack) error {
+	clusterIssuer := s.Config.Certmgr.ClusterIssuer
+	issuer := s.Config.Certmgr.Issuer
 
 	delErr := s.kube.DeleteIngress(userId, svc.Name+"-ingress")
 	if delErr != nil {
 		glog.Warning(delErr)
 	}
 	_, err := s.kube.CreateIngress(userId, s.domain, svc.Name,
-		svc.Spec.Ports, stack.Secure)
+		svc.Spec.Ports, stack.Secure, clusterIssuer, issuer)
 	if err != nil {
 		glog.Errorf("Error creating ingress for %s\n", svc.Name)
 		glog.Error(err)

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -183,6 +183,12 @@ func main() {
 	server.homePvcSuffix = cfg.HomePvcSuffix
 	server.requireApproval = cfg.RequireApproval
 
+	if cfg.Certmgr.ClusterIssuer != "" {
+		glog.Infof("Using TLS clsuter issuer: %s\n", cfg.Certmgr.ClusterIssuer)
+	} else if cfg.Certmgr.Issuer != "" {
+		glog.Infof("Using TLS issuer: %s\n", cfg.Certmgr.Issuer)
+	}
+
 	server.ingress = config.IngressTypeNodePort
 	if cfg.Ingress != "" {
 		server.ingress = cfg.Ingress
@@ -1607,6 +1613,11 @@ func (s *Server) createIngressRule(userId string, svc *v1.Service, stack *api.St
 		return err
 	}
 	glog.V(4).Infof("Started ingress for service %s (secure=%t)\n", svc.Name, stack.Secure)
+        if cfg.Certmgr.ClusterIssuer != "" {
+                glog.Infof("Using TLS clsuter issuer: %s\n", clusterIssuer)
+        } else if cfg.Certmgr.Issuer != "" {
+                glog.Infof("Using TLS issuer: %s\n", issuer)
+        }
 	return nil
 }
 

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -153,7 +153,7 @@ cat << EOF > /apiserver.json
         "tls": $SMTP_TLS
     },
     "certmgr": {
-        "cluster-issuer": "$TLS_CLUSTER_ISSUER",
+        "clusterIssuer": "$TLS_CLUSTER_ISSUER",
         "issuer": "$TLS_ISSUER"
     },
     "specs": {

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -152,6 +152,11 @@ cat << EOF > /apiserver.json
         "port": $SMTP_PORT,
         "tls": $SMTP_TLS
     },
+    "certmgr": {
+        "cluster-issuer": "$CERTMGR_CLUSTER_ISSUER",
+        "issuer": "$CERTMGR_ISSUER",
+        "namespace": "$CERTMGR_NAMESPACE"
+    },
     "specs": {
         "path": "/specs"
     },

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -153,9 +153,8 @@ cat << EOF > /apiserver.json
         "tls": $SMTP_TLS
     },
     "certmgr": {
-        "cluster-issuer": "$CERTMGR_CLUSTER_ISSUER",
-        "issuer": "$CERTMGR_ISSUER",
-        "namespace": "$CERTMGR_NAMESPACE"
+        "cluster-issuer": "$TLS_CLUSTER_ISSUER",
+        "issuer": "$TLS_ISSUER"
     },
     "specs": {
         "path": "/specs"

--- a/apiserver/glide.lock
+++ b/apiserver/glide.lock
@@ -1,5 +1,5 @@
-hash: 83b9fb5a3b8c3d14513052f6eddb50f657e9a48c577d491e08f2df76651e7bf8
-updated: 2020-09-24T18:33:37.54458096Z
+hash: 193a2032cae5621b631cbaa12ee390d4037bc458e517afd4767b791bf2e88ebb
+updated: 2020-09-24T21:08:07.662068919Z
 imports:
 - name: github.com/ant0ine/go-json-rest
   version: 37ad7dc626602a8355801da6acd85155655520f8
@@ -38,7 +38,7 @@ imports:
   subpackages:
   - spdy
 - name: github.com/fsnotify/fsnotify
-  version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
+  version: 7f4cf4dd2b522a984eaca51d1ccee54101d3414a
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/gogo/protobuf
@@ -47,7 +47,7 @@ imports:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
   version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
@@ -90,35 +90,33 @@ imports:
 - name: github.com/kr/fs
   version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
 - name: github.com/magiconair/properties
-  version: 61b492c03cf472e0c6419be5899b8e0dc28b1b88
+  version: 0e5c09062c2daef666bd279e2d2d9f25f218f2be
 - name: github.com/mitchellh/mapstructure
-  version: 53818660ed4955e899c0bcafa97299a388bd7c8e
+  version: 9e1e4717f8567d7ead72d070d064ad17d444a67e
 - name: github.com/modern-go/reflect2
   version: 4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd
-- name: github.com/pelletier/go-buffruneio
-  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
-  version: 0049ab3dc4c4c70a9eee23087437b69c0dde2130
+  version: e6908614ee78e01b71b0adadb1379acff6da9320
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pkg/sftp
-  version: 4d0e916071f68db74f8a73926335f809396d6b42
+  version: 60ec050bd01725d84d5b7624e27967babafd033d
+- name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/Sirupsen/logrus
   version: 6699a89a232f3db797f2e280639854bbc4b89725
   repo: https://github.com/sirupsen/logrus.git
-- name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/spf13/afero
   version: b28a7effac979219c2a2ed6205a4d70e4b1bcd02
   subpackages:
   - mem
   - sftp
 - name: github.com/spf13/cast
-  version: e31f36ffc91a2ba9ddb72a4b6a607ff9b3d3cb63
+  version: 8d17101741c81653ee960aa20f9febb31f1218aa
 - name: github.com/spf13/cobra
   version: f62e98d28ab7ad31d707ba837a966378465c7b57
 - name: github.com/spf13/jwalterweatherman
-  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+  version: ce7498392da6d96a17a449ce0e96172af864d822
 - name: github.com/spf13/pflag
   version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/spf13/viper
@@ -126,7 +124,7 @@ imports:
 - name: github.com/StephanDollberg/go-json-rest-middleware-jwt
   version: ff6ad319595d78f039df9a91bbac8b8bd120a764
 - name: github.com/tredoe/osutil
-  version: 7d3ee1afa71c90fd1514c8f557ae6c5f414208eb
+  version: 48cb8f4fe1028bc10dcd22bd57fd26b06dcf0d00
   subpackages:
   - user/crypt
   - user/crypt/apr1_crypt
@@ -137,7 +135,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/xeipuuv/gojsonpointer
-  version: 4e3ac2762d5f479393488629ee9370b50873b3a6
+  version: 02993c407bfbf5f6dae44c4f4b1cf6a39b5fc5bb
 - name: github.com/xeipuuv/gojsonreference
   version: bd5ef7bd5415a7ac448318e64f11a24cd21e594b
 - name: github.com/xeipuuv/gojsonschema

--- a/apiserver/glide.lock
+++ b/apiserver/glide.lock
@@ -1,5 +1,5 @@
-hash: c18fedcbbb95992ad6b5e4e14ce3e1ca5b89263eebefe784ccafaf0b8ec30d4c
-updated: 2018-09-05T14:21:20.225404-05:00
+hash: 83b9fb5a3b8c3d14513052f6eddb50f657e9a48c577d491e08f2df76651e7bf8
+updated: 2020-09-24T18:33:37.54458096Z
 imports:
 - name: github.com/ant0ine/go-json-rest
   version: 37ad7dc626602a8355801da6acd85155655520f8
@@ -11,7 +11,7 @@ imports:
   subpackages:
   - winterm
 - name: github.com/coreos/etcd
-  version: fca8add78a9d926166eb739b8e4a124434025ba3
+  version: c23606781f63d09917a1e7abfcefeb337a9608ea
   subpackages:
   - client
   - pkg/pathutil
@@ -33,6 +33,10 @@ imports:
   subpackages:
   - pkg/term
   - pkg/term/windows
+- name: github.com/docker/spdystream
+  version: 449fdfce4d962303d702fec724ef0ad181c92528
+  subpackages:
+  - spdy
 - name: github.com/fsnotify/fsnotify
   version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
 - name: github.com/ghodss/yaml
@@ -89,6 +93,8 @@ imports:
   version: 61b492c03cf472e0c6419be5899b8e0dc28b1b88
 - name: github.com/mitchellh/mapstructure
   version: 53818660ed4955e899c0bcafa97299a388bd7c8e
+- name: github.com/modern-go/reflect2
+  version: 4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd
 - name: github.com/pelletier/go-buffruneio
   version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
 - name: github.com/pelletier/go-toml
@@ -97,11 +103,11 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pkg/sftp
   version: 4d0e916071f68db74f8a73926335f809396d6b42
+- name: github.com/Sirupsen/logrus
+  version: 6699a89a232f3db797f2e280639854bbc4b89725
+  repo: https://github.com/sirupsen/logrus.git
 - name: github.com/sirupsen/logrus
   version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
-- name: github.com/Sirupsen/logrus
-  version: 3791101e143bf0f32515ac23e831475684f61229
-  repo: https://github.com/sirupsen/logrus.git
 - name: github.com/spf13/afero
   version: b28a7effac979219c2a2ed6205a4d70e4b1bcd02
   subpackages:
@@ -136,6 +142,10 @@ imports:
   version: bd5ef7bd5415a7ac448318e64f11a24cd21e594b
 - name: github.com/xeipuuv/gojsonschema
   version: 83a7f6369d552cba07cdeea7dc622f1161a07deb
+- name: go.etcd.io/etcd
+  version: c23606781f63d09917a1e7abfcefeb337a9608ea
+  subpackages:
+  - v3/pkg/types
 - name: golang.org/x/crypto
   version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
@@ -240,11 +250,14 @@ imports:
   - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
+  - pkg/util/httpstream
+  - pkg/util/httpstream/spdy
   - pkg/util/intstr
   - pkg/util/intstr
   - pkg/util/json
   - pkg/util/net
   - pkg/util/rand
+  - pkg/util/remotecommand
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/validation
@@ -253,6 +266,7 @@ imports:
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
+  - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
   version: 23781f4d6632d88e869066eaebb743857aa1ef9b
@@ -334,9 +348,12 @@ imports:
   - tools/metrics
   - tools/pager
   - tools/reference
+  - tools/remotecommand
   - transport
+  - transport/spdy
   - util/buffer
   - util/cert
+  - util/exec
   - util/flowcontrol
   - util/homedir
   - util/integer

--- a/apiserver/glide.yaml
+++ b/apiserver/glide.yaml
@@ -69,3 +69,5 @@ import:
   version: "3.3"
   subpackages:
   - v3/pkg/types
+- package: github.com/pkg/sftp
+  version: ~1.12.0

--- a/apiserver/glide.yaml
+++ b/apiserver/glide.yaml
@@ -11,16 +11,14 @@ import:
   subpackages:
   - rest
 - package: github.com/coreos/etcd
-  version: ^3.0.7
+  version: "3.3"
   subpackages:
   - client
-# Git Account name changed and broke old dependencies
-# https://github.com/sirupsen/logrus/issues/553#issuecomment-306591437
 - package: github.com/sirupsen/logrus
   version: v1.0.3
 - package: github.com/Sirupsen/logrus
-  repo: https://github.com/sirupsen/logrus.git
   version: master
+  repo: https://github.com/sirupsen/logrus.git
 - package: github.com/docker/docker
   version: ^1.12.1
   subpackages:
@@ -35,6 +33,7 @@ import:
   version: 83a7f6369d552cba07cdeea7dc622f1161a07deb
 - package: golang.org/x/crypto
   subpackages:
+  - bcrypt
   - ssh/terminal
 - package: golang.org/x/net
   subpackages:
@@ -54,16 +53,19 @@ import:
   - pkg/util/intstr
   - pkg/watch
   - pkg/watch/json
-- package: golang.org/x/crypto
-  subpackages:
-  - bcrypt
 - package: github.com/tredoe/osutil
   subpackages:
   - user/crypt/apr1_crypt
 - package: k8s.io/client-go
-  version: 7.0
+  version: "7.0"
 - package: github.com/gogo/protobuf
-  #  version: v0.3
   subpackages:
   - proto
 - package: github.com/golang/protobuf
+- package: github.com/docker/spdystream
+- package: github.com/modern-go/reflect2
+  version: ~1.0.1
+- package: go.etcd.io/etcd
+  version: "3.3"
+  subpackages:
+  - v3/pkg/types

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	DefaultLimits   DefaultLimits `json:"defaultLimits"`
 	Etcd            Etcd          `json:"etcd"`
 	Kubernetes      Kubernetes    `json:"kubernetes"`
+	Certmgr         Certmgr       `json:"certmgr"`
 	Email           Email         `json:"email"`
 	Specs           Specs         `json:"specs"`
 	HomePvcSuffix   string        `json:"homePvcSuffix"`
@@ -60,6 +61,11 @@ type Kubernetes struct {
 	StorageClass      string  `json:"pvcStorageClass"`
 	QPS               float32 `json:"qps"`
 	Burst             int     `json:"burst"`
+}
+type Certmgr struct {
+	ClusterIssuer	  string  `json:"clusterIssuer"`
+	Issuer		  string  `json:"issuer"`
+	Namespace	  string  `json:"namespace"`
 }
 type Email struct {
 	Host string `json:"host"`

--- a/apiserver/pkg/config/config.go
+++ b/apiserver/pkg/config/config.go
@@ -65,7 +65,6 @@ type Kubernetes struct {
 type Certmgr struct {
 	ClusterIssuer	  string  `json:"clusterIssuer"`
 	Issuer		  string  `json:"issuer"`
-	Namespace	  string  `json:"namespace"`
 }
 type Email struct {
 	Host string `json:"host"`

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -892,18 +892,20 @@ func (k *KubeHelper) CreateIngress(pid string, domain string, service string, po
 	}
 
 	hosts := []string{}
+	rootHost := fmt.Sprintf("%s", domain)
+	wildcardHost := fmt.Sprintf("*.%s", domain)
 	if len(ports) == 1 {
 		host := fmt.Sprintf("%s.%s", service, domain)
-		wildcardHost := fmt.Sprintf("*.%s", domain)
 		rule := k.createIngressRule(service, host, int(ports[0].Port))
 		ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
+		hosts = append(hosts, rootHost)
 		hosts = append(hosts, wildcardHost)
 	} else {
 		for _, port := range ports {
 			host := fmt.Sprintf("%s-%d.%s", service, port.Port, domain)
-			wildcardHost := fmt.Sprintf("*.%s", domain)
 			rule := k.createIngressRule(service, host, int(port.Port))
 			ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
+			hosts = append(hosts, rootHost)
 			hosts = append(hosts, wildcardHost)
 		}
 	}

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -932,11 +932,6 @@ func (k *KubeHelper) CreateIngress(pid string, domain string, service string, po
 		},
 	}
 
-	// If cert-manager is present, add the secret name
-	if (clusterIssuer != "" || issuer != "") {
-		ingress.Spec.TLS[0].SecretName = service + "-tls"
-	}
-
 	return k.CreateUpdateIngress(pid, ingress, update)
 }
 

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -894,15 +894,17 @@ func (k *KubeHelper) CreateIngress(pid string, domain string, service string, po
 	hosts := []string{}
 	if len(ports) == 1 {
 		host := fmt.Sprintf("%s.%s", service, domain)
+		wildcardHost := fmt.Sprintf("*.%s", domain)
 		rule := k.createIngressRule(service, host, int(ports[0].Port))
 		ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
-		hosts = append(hosts, host)
+		hosts = append(hosts, wildcardHost)
 	} else {
 		for _, port := range ports {
 			host := fmt.Sprintf("%s-%d.%s", service, port.Port, domain)
+			wildcardHost := fmt.Sprintf("*.%s", domain)
 			rule := k.createIngressRule(service, host, int(port.Port))
 			ingress.Spec.Rules = append(ingress.Spec.Rules, rule)
-			hosts = append(hosts, host)
+			hosts = append(hosts, wildcardHost)
 		}
 	}
 

--- a/apiserver/pkg/version/.gitignore
+++ b/apiserver/pkg/version/.gitignore
@@ -1,0 +1,1 @@
+version.go


### PR DESCRIPTION
## Problem
We have decided to use `cert-manager`, but our current Ingress creation logic is missing some necessary changes.

## Approach
* Read ISSUER / CLUSTER_ISSUER from envvar, add this as annotation to Ingress rules as we create them
* ~~Added `secretName` to `tls` section~~ We can reuse the same secret across namespaces, like we used to
* Change `tls.host` to be `*.$DOMAIN`, instead of an explicit domain 
* Update `apiserver` to use golang 1.15 / Debian Buster
* Added missing build dependency for `github.com/docker/spdystream`
* Reorder/refactor Docker file to take advantage of layer caching

## How to Test
See Test Case for https://github.com/nds-org/workbench-helm-chart/pull/21
