### PR TITLE
Fix email template output directory

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get -qq update && \
 COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-*-amd64 /ndslabsctl/
 COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/apiserver-linux-amd64 /usr/local/bin/apiserver
 
-COPY entrypoint.sh templates /
+COPY entrypoint.sh /entrypoint.sh
+COPY templates /templates
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apiserver"]


### PR DESCRIPTION
## Problem
A recent PR has inadvertently moved the location of the templates used to send automated e-mails.

## Approach
Fix the output directory back to `/templates`

## How to Test
1. Deploy Helm chart running this `apiserver` image
2. Sign up for a new account
    * You should **not** get an error saying that every username has already been taken