### PR TITLE
Testing / enhancing oauth integration

### DIFF
--- a/apiserver/.dockerignore
+++ b/apiserver/.dockerignore
@@ -1,4 +1,4 @@
-*/build/*
+**/build/*
 **/vendor/*
 
 .dockerignore

--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -18,7 +18,9 @@ COPY glide.* ./
 RUN glide install --strip-vendor
 
 # Build golang code
-COPY . ./
+COPY pkg ./pkg/
+COPY cmd ./cmd/
+COPY build.sh ./
 RUN ./build.sh docker
 
 # Create runtime container
@@ -37,6 +39,7 @@ COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-*-
 COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/apiserver-linux-amd64 /usr/local/bin/apiserver
 
 COPY entrypoint.sh /entrypoint.sh
+COPY postman /postman/
 COPY templates /templates
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/apiserver/build.sh
+++ b/apiserver/build.sh
@@ -4,6 +4,7 @@ BUILD_DATE=`date +%Y-%m-%d\ %H:%M`
 VERSIONFILE="pkg/version/version.go"
 VERSION="1.2.0"
 
+set -e
 
 if [ "$1" == "local" ] || [ "$1" == "docker" ]; then
 

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -548,7 +548,8 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 		return
 	}
 
-	oauth_url := "https://ngress-ingress-nginx-controller.kube-system.svc.cluster.local/oauth2/userinfo"
+	host :=  "www." + s.Config.Domain
+	oauth_url := "https://" + host + "/oauth2/userinfo"
 	glog.Infof("Validating OAuth2 cookie: %s", oauth_url)
 	req, err := http.NewRequest("GET", oauth_url, nil)
 	if err != nil {
@@ -558,7 +559,6 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 	}
 
 	client := &http.Client{}
-	host :=  "www." + s.Config.Domain
 	req.Header.Add("Host", host)
 	req.AddCookie(oauth_cookie)
 	resp, err := client.Do(req)
@@ -592,8 +592,8 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 	oauth_accessToken := oauth_fields["accessToken"]
 	//	oauth_otherTokenStr := oauth_fields["otherTokens"]
 	oauth_email := oauth_fields["email"]
-	oauth_name := strings.Split(oauth_fields["name"], "@")[0]
-	oauth_user := oauth_fields["preferredUsername"]
+	oauth_name := oauth_fields["name"]
+	oauth_user := strings.Split(auth_fields["preferredUsername"], "@")[0]
 
 	// TODO: do we need to support rd parameter?
 

--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -406,20 +406,10 @@ func (s *Server) start(cfg *config.Config, adminPasswd string) {
 	}
 	glog.Infof("Listening on %s", cfg.Port)
 
-	// internal admin server, currently only handling oauth registration
-	adminsrv := &http.Server{
-		Addr:    ":" + cfg.AdminPort,
-		Handler: http.HandlerFunc(s.RegisterUserOauth),
-	}
-	glog.Infof("Admin server listening on %s", cfg.AdminPort)
-
 	stop := make(chan os.Signal, 2)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		httpsrv.ListenAndServe()
-	}()
-	go func() {
-		adminsrv.ListenAndServe()
 	}()
 	<-stop
 
@@ -539,17 +529,16 @@ func Version(w rest.ResponseWriter, r *rest.Request) {
 }
 
 func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
-	oauth_cookie, err := r.Cookie("_oauth2_proxy") // cookie_segments[1]
 	glog.Info("Checking for OAuth2 cookie...")
-
+	oauth_cookie, err := r.Cookie("_oauth2_proxy") // cookie_segments[1]
 	if err != nil {
 		glog.Error(err)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 
-	host :=  "www." + s.Config.Domain
-	oauth_url := "https://" + host + "/oauth2/userinfo"
+	oauth_host :=  "https://www." + s.Config.Domain
+	oauth_url := oauth_host + "/oauth2/userinfo"
 	glog.Infof("Validating OAuth2 cookie: %s", oauth_url)
 	req, err := http.NewRequest("GET", oauth_url, nil)
 	if err != nil {
@@ -558,9 +547,10 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 		return
 	}
 
-	client := &http.Client{}
-	req.Header.Add("Host", host)
+	req.Header.Add("Host", "www." + s.Config.Domain)
 	req.AddCookie(oauth_cookie)
+
+	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		glog.Error(err)
@@ -589,21 +579,33 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 		return
 	}
 
-	oauth_accessToken := oauth_fields["accessToken"]
-	//	oauth_otherTokenStr := oauth_fields["otherTokens"]
 	oauth_email := oauth_fields["email"]
-	oauth_name := oauth_fields["name"]
-	oauth_user := strings.Split(auth_fields["preferredUsername"], "@")[0]
-
-	// TODO: do we need to support rd parameter?
-
-	if oauth_email == "" || oauth_user == "" {
-		glog.Warning("No oauth header found: " + oauth_name + " (" + oauth_user + ": " + oauth_email + ") ") // + oauth_accessToken)
+	if oauth_email == "" {
+		glog.Warning("No OAuth fields found.") // + oauth_accessToken)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 
-/*
+
+	// Fallback to Email prefix if username not available
+	oauth_user := strings.Split(oauth_fields["preferredUsername"], "@")[0]
+	if oauth_user == "" {
+		oauth_user = strings.Split(oauth_email, "@")[0]
+	}
+
+	// Fallback to Username if full name not available
+	oauth_name := oauth_fields["name"]
+	if oauth_name == "" {
+		oauth_name = oauth_user
+	}
+
+	// TODO: Wire up accessToken? Is this needed for anything?
+	// oauth_accessToken := oauth_fields["accessToken"]
+
+	// TODO: Wire up otherTokens. This is needed for (at least) the MDF Forge Notebook
+	// Assign other tokens, if presented
+/*	oauth_otherTokenStr := oauth_fields["otherTokens"]
+	if oauth_otherTokensStr != "" {
 		tokens := make(map[string]string)
 		otherTokens := strings.Split(otherTokenStr, " ")
 		for _, kvpair := range otherTokens {
@@ -611,18 +613,19 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 			tokens[kv[0]] = kv[1]
 		}
 
+		// Write token(s) to user's home directory
 		err := s.writeAuthPayload(user, tokens)
 		if err != nil {
 			glog.Error(err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-*/		
-
+	}
+*/
 				
 	// OAuth2 token is valid and contains everything we need, register account if necessary
-	glog.Infof("Creating/updating account for %s %s %s %s\n", oauth_user, oauth_email, oauth_name, oauth_accessToken)
-	//	glog.Infof("Other tokens %s\n", otherTokens)
+	glog.Infof("Creating/updating account for %s %s %s\n", oauth_user, oauth_email, oauth_name) //, oauth_accessToken)
+//	glog.V(4).Infof("Other tokens %s\n", otherTokens)
 				
 
 	oauth_account := s.getAccountByEmail(oauth_email)
@@ -665,29 +668,14 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
        		}
        	}
 	        
+	//  Issue JWT
        	token, err := s.getTemporaryToken(oauth_user)
        	if err != nil {
        		glog.Error(err)
-       		w.WriteHeader(http.StatusOK)
+       		w.WriteHeader(http.StatusUnauthorized)
        		return
        	}
-				
 
-	//  Issue JWT
-        tokenCookie := http.Cookie{Name: "token", Value: token, Domain: s.domain, Path: "/", Secure: true, HttpOnly: false, Expires: time.Now().AddDate(0,0,1)}
-        namespaceCookie := http.Cookie{Name: "namespace", Value: oauth_user, Domain: s.domain, Path: "/", Secure: true, HttpOnly: false, Expires: time.Now().AddDate(0,0,1)}
-
-        glog.Info("Setting Cookies:\n")
-        fmt.Println(tokenCookie)
-        fmt.Println(namespaceCookie)
-	//expiration := time.Now().Add(365 * 24 * time.Hour)
-        // http.SetCookie(w, &tokenCookie)
-        // http.SetCookie(w, &namespaceCookie)
-
-        w.Header().Add("Set-Cookie", "token=" + token)
-        w.Header().Add("Set-Cookie", "namespace=" + oauth_user)
-
-	//w.WriteHeader(http.StatusOK)
 	w.WriteJson(&token)
 	return
 }
@@ -899,10 +887,7 @@ func (s *Server) createLMABasicAuthSecret() error {
 }
 
 func (s *Server) setupAccount(account *api.Account) error {
-	_, err := s.kube.CreateNamespace(account.Namespace)
-	if err != nil {
-		return err
-	}
+	s.kube.CreateNamespace(account.Namespace)
 
 	// Create a PVC for this user's data
 	storageClass := s.Config.Kubernetes.StorageClass
@@ -919,19 +904,12 @@ func (s *Server) setupAccount(account *api.Account) error {
 			StorageQuota:  s.Config.DefaultLimits.StorageDefault,
 		}
 	}
-	_, err = s.kube.CreateResourceQuota(account.Namespace,
+	s.kube.CreateResourceQuota(account.Namespace,
 		account.ResourceLimits.CPUMax,
 		account.ResourceLimits.MemoryMax)
-	if err != nil {
-		return err
-	}
-
-	_, err = s.kube.CreateLimitRange(account.Namespace,
+	s.kube.CreateLimitRange(account.Namespace,
 		account.ResourceLimits.CPUDefault,
 		account.ResourceLimits.MemoryDefault)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -3368,98 +3346,4 @@ func (s *Server) writeAuthPayload(userId string, tokens map[string]string) error
 		return err
 	}*/
 	return nil
-}
-
-// Register a user via oauth
-func (s *Server) RegisterUserOauth(w http.ResponseWriter, r *http.Request) {
-
-	rd := r.FormValue("rd")
-	if rd == "" {
-		rd = "https://www." + s.domain + "/dashboard"
-	}
-
-	accessToken := r.Header.Get("X-Forwarded-Access-Token")
-	otherTokenStr := r.Header.Get("X-Forwarded-Other-Tokens")
-	email := r.Header.Get("X-Forwarded-Email")
-	user := r.Header.Get("X-Forwarded-User")
-
-	if accessToken == "" || email == "" || user == "" {
-		glog.Warning("No oauth header found")
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
-	tokens := make(map[string]string)
-	otherTokens := strings.Split(otherTokenStr, " ")
-	for _, kvpair := range otherTokens {
-		kv := strings.Split(kvpair, "=")
-		tokens[kv[0]] = kv[1]
-	}
-
-	err := s.writeAuthPayload(user, tokens)
-	if err != nil {
-		glog.Error(err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	glog.Infof("Creating/updating account for %s %s %s\n", user, email, accessToken)
-	glog.Infof("Other tokens %s\n", otherTokens)
-
-	account := s.getAccountByEmail(email)
-	if account == nil {
-		act := api.Account{
-			Name:         user,
-			Description:  "Oauth shadow account",
-			Namespace:    user,
-			EmailAddress: email,
-			Password:     s.kube.RandomString(10),
-			Organization: "",
-			Created:      time.Now().Unix(),
-			LastLogin:    time.Now().Unix(),
-			NextURL:      rd,
-		}
-		act.Status = api.AccountStatusApproved
-
-		err := s.etcd.PutAccount(act.Namespace, &act, true)
-		if err != nil {
-			glog.Error(err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		err = s.setupAccount(&act)
-		if err != nil {
-			glog.Error(err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-	} else {
-		account.LastLogin = time.Now().Unix()
-		account.NextURL = rd
-
-		err := s.etcd.PutAccount(account.Namespace, account, true)
-		if err != nil {
-			glog.Error(err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-	}
-
-	token, err := s.getTemporaryToken(user)
-	if err != nil {
-		glog.Error(err)
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-
-	glog.Infof("Setting Cookie\n")
-	//expiration := time.Now().Add(365 * 24 * time.Hour)
-	http.SetCookie(w, &http.Cookie{Name: "token", Value: token, Domain: s.domain, Path: "/"})
-	http.SetCookie(w, &http.Cookie{Name: "namespace", Value: user, Domain: s.domain, Path: "/"})
-
-	glog.Infof("Redirecting to %s\n", rd)
-	http.Redirect(w, r, rd, 301)
-	return
 }

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -11,6 +11,16 @@ if [ "$1" = 'apiserver' ]; then
 	if [ -z "$ETCD_ADDR" ]; then 
 		ETCD_ADDR="localhost:4001"
 	fi
+	
+	ETCD_HOST="$(echo $ETCD_ADDR | awk -F[/:] '{print $1}')"
+	if [ -z "$ETCD_HOST" ]; then 
+		ETCD_HOST="localhost"
+	fi
+
+	ETCD_PORT="$(echo $ETCD_ADDR | awk -F[/:] '{print $2}')"
+	if [ -z "$ETCD_PORT" ]; then 
+		ETCD_PORT="4001"
+	fi
 
 	if [ -z "$KUBERNETES_ADDR" ]; then 
 		KUBERNETES_ADDR="https://localhost:6443"
@@ -168,6 +178,14 @@ cat << EOF > /apiserver.json
     ]
 }
 EOF
+
+
+	# Wait for etcd to come online
+	echo "Waiting for etcd at $ETCD_ADDR..."
+	while ! nc -z $ETCD_HOST $ETCD_PORT; do   
+		sleep 0.1 # wait for 1/10 of the second before check again
+	done
+        echo "Connecting to etcd at $ETCD_ADDR..."
 
 	if [ -z "$SPEC_GIT_REPO" ]; then 
 		SPEC_GIT_REPO=https://github.com/nds-org/ndslabs-specs

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -192,7 +192,7 @@ EOF
 	umask 0
 
 	if [ -z "$TEST" ]; then
-		apiserver -conf /apiserver.json --logtostderr=true -v=4 -passwd $ADMIN_PASSWORD 
+		apiserver -conf /apiserver.json --logtostderr=true -v=2 -passwd $ADMIN_PASSWORD 
         else
                 echo "Running binary with test/coverage instrumentation"
                 echo "Writing output to $VOLUME_PATH/coverage.out"

--- a/apiserver/pkg/kube/kube.go
+++ b/apiserver/pkg/kube/kube.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
+	// "encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -739,25 +739,25 @@ func (k *KubeHelper) WatchEvents(handler events.EventHandler) {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				if obj.(*v1.Pod).GetCreationTimestamp().After(startTime) {
-					fmt.Printf("pod added: %s \n", obj.(*v1.Pod).Name)
+					// fmt.Printf("pod added: %s \n", obj.(*v1.Pod).Name)
 					handler.HandlePodEvent("ADDED", obj.(*v1.Pod))
-					data, _ := json.MarshalIndent(obj.(*v1.Pod), "", "    ")
-					fmt.Println(string(data))
+					// data, _ := json.MarshalIndent(obj.(*v1.Pod), "", "    ")
+					// fmt.Println(string(data))
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				if obj.(*v1.Pod).GetDeletionTimestamp().After(startTime) {
-					fmt.Printf("pod deleted: %s \n", obj.(*v1.Pod).Name)
+					// fmt.Printf("pod deleted: %s \n", obj.(*v1.Pod).Name)
 					handler.HandlePodEvent("DELETED", obj.(*v1.Pod))
-					data, _ := json.MarshalIndent(obj.(*v1.Pod), "", "    ")
-					fmt.Println(string(data))
+					// data, _ := json.MarshalIndent(obj.(*v1.Pod), "", "    ")
+					// fmt.Println(string(data))
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				fmt.Printf("pod updated: %s %s \n", oldObj.(*v1.Pod).Name, newObj.(*v1.Pod).Name)
+				// fmt.Printf("pod updated: %s %s \n", oldObj.(*v1.Pod).Name, newObj.(*v1.Pod).Name)
 				handler.HandlePodEvent("UPDATED", newObj.(*v1.Pod))
-				data, _ := json.MarshalIndent(newObj.(*v1.Pod), "", "    ")
-				fmt.Println(string(data))
+				// data, _ := json.MarshalIndent(newObj.(*v1.Pod), "", "    ")
+				// fmt.Println(string(data))
 			},
 		},
 	)
@@ -774,16 +774,16 @@ func (k *KubeHelper) WatchEvents(handler events.EventHandler) {
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				if obj.(*v1.ReplicationController).GetCreationTimestamp().After(startTime) {
-					fmt.Printf("rc added: %s \n", obj.(*v1.ReplicationController).Name)
+					// fmt.Printf("rc added: %s \n", obj.(*v1.ReplicationController).Name)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				if obj.(*v1.ReplicationController).GetDeletionTimestamp().After(startTime) {
-					fmt.Printf("rc deleted: %s \n", obj.(*v1.ReplicationController).Name)
+					// fmt.Printf("rc deleted: %s \n", obj.(*v1.ReplicationController).Name)
 				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				fmt.Printf("rc changed %s -> %s\n", oldObj.(*v1.ReplicationController).Name, newObj.(*v1.ReplicationController).Name)
+				// fmt.Printf("rc changed %s -> %s\n", oldObj.(*v1.ReplicationController).Name, newObj.(*v1.ReplicationController).Name)
 			},
 		},
 	)

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Build: docker build -t ndslabs/angular-ui .
 #
-FROM ndslabs/ng-base:latest
+FROM ndslabs/ng-base:focal-erbium
 
 # Set build information here before building (or at build time with --build-args version=X.X.X)
 ARG version="1.2.0"
@@ -12,8 +12,11 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     NODE_ENV="production" \
     BASEDIR="/home"
 
+
 # Copy in our app source
 WORKDIR $BASEDIR
+COPY package.json package-lock.json $BASEDIR/
+RUN npm install
 COPY . $BASEDIR/
 
 # Update build date / version number and enable backports
@@ -21,8 +24,7 @@ RUN /bin/sed -i -e "s#^\.constant('BuildVersion', '.*')#.constant('BuildVersion'
     /bin/sed -i -e "s#^\.constant('BuildDate', .*)#.constant('BuildDate', new Date('$(date)'))#" "$BASEDIR/ConfigModule.js"
 
 # Install app dependencies
-RUN npm install && \
-    grunt swagger-js-codegen
+RUN grunt swagger-js-codegen
 
 # Set up some default environment variable
 ENV APISERVER_HOST="localhost" \

--- a/gui/Dockerfile.ng-base
+++ b/gui/Dockerfile.ng-base
@@ -1,4 +1,6 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install NodeJS and friends
 RUN apt-get -qq update && \
@@ -10,7 +12,7 @@ RUN apt-get -qq update && \
       npm \
       wget \
       curl && \
-    curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && \
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
     apt-get -qq install nodejs && \
     apt-get -qq autoremove && \
     apt-get -qq autoclean && \

--- a/gui/server.js
+++ b/gui/server.js
@@ -225,26 +225,35 @@ app.get('/cauth/auth', function(req, res) {
   let token = req.cookies['token'];
   logger.log("debug", "Checking user session: " + token);
   
-  let requestedUrl = req.headers['x-original-url'];
+  let requestedUrl = req.headers['x-original-url'] || req.headers['origin'];
   let prefix = (secureCookie ? 'https://' : 'http://') + subdomainPrefix;
   let checkHost = '';
   
   if (!token) {
       res.sendStatus(401);
       return;
-  } else if (requestedUrl.indexOf(prefix+cookieDomain) !== 0) {
+  } else if (requestedUrl && requestedUrl.indexOf(prefix+cookieDomain) !== 0) {
      // if request starts with an arbitrary host (e.g. not 'subdomainPrefix.'), 
      //    we need to check authorization
     checkHost = requestedUrl.replace(/https?:\/\//, '').replace(/\/.*$/, '');
-    //logger.log("debug", `Checking token's access to ${checkHost}`);
+    logger.log("info", `Checking token's access to ${checkHost}`);
   }
+
+  logger.log("info", `Requested URL: ${requestedUrl}`);
+  logger.log("info", `Prefix: ${prefix}`);
+  logger.log("info", `Cookie Domain: ${cookieDomain}`);
+  logger.log("info", `Auth-free: ${prefix+cookieDomain}`);
+  logger.log("info", `Checking Host: ${checkHost}`);
+
+  let apiPathSuffix = apiPath + '/check_token' + (checkHost ? '?host=' + checkHost : '');
+  logger.log("info", `CheckHost Path Suffix: ${apiPathSuffix}`);
 
   // If token was given, check that it's valid
   http.get({ 
       protocol: apiProtocol,
       host: apiHost,
       port: apiPort,
-      path: apiPath + '/check_token' + (checkHost ? '?host=' + checkHost : ''), 
+      path: apiPathSuffix, 
       headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer ' + token
@@ -259,6 +268,7 @@ app.get('/cauth/auth', function(req, res) {
                         `Status Code: ${statusCode}`);
     }
     if (error) {
+      logger.log('error', 'CheckHost Failed')
       logger.log('error', error.message);
       // consume response data to free up memory
       resp.resume();

--- a/gui/shared/navbar/NavbarController.js
+++ b/gui/shared/navbar/NavbarController.js
@@ -79,7 +79,11 @@ angular
     $cookies.remove('namespace', CookieOptions);
     
     // TODO: Can we avoid hard-coding this URL?
-    $window.location.href = '/landing/';
+    if ($scope.enableOAuth) {
+      $window.location.href = '/oauth2/sign_out'; // '/login/' + ($rootScope.rd ? 'rd=' : '');
+    } else {
+      $window.location.href = '/landing/';
+    }
   };
   
   $scope.brand = 

--- a/gui/swagger.yaml
+++ b/gui/swagger.yaml
@@ -399,6 +399,20 @@ paths:
             properties:
               data:
                 type: string
+  /validate:
+    get:
+      description: |
+        Check if the user has an active/valid OAuth session
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/definitions/Token'
+        '401':
+          description: Not logged in
   /register:
     post:
       description: |


### PR DESCRIPTION
## Problem
SSO is fragile and/or not working. We would like to harden this a bit and add some level of support for logging in with CILogon.

Fixes #254

## Approach
* Support oauth2 proxy + Keycloak + CILogon configuration
* Add a new endpoint that will validate the `_oauth2_proxy` cookie / session data and use it to ensure that an account is created for the user in Workbench, then issue a JWT for the user
* Add logic in the dashboard UI module that will send the `_oauth2_proxy` cookie to the new endpoint mentioned above if the user reaches a protected part of the dashboard without a valid JWT

Other minor changes include:
* Speed improvements for `apiserver` and `gui` Docker image builds
* Upgrade `ng-base` Docker image from `xenial` -> `focal` (Ubuntu 20.04 LTS) and `carbon` -> `erbium`(NodeJS 12 LTS)
* Cut down on the ambient `apiserver` container log spam
* Wait for `etcd` to finish its own container startup before continuing `apiserver` startup

## How to Test
See https://github.com/nds-org/workbench-helm-chart/pull/24 for test steps