### PR TITLE
Wait for etcd to startup before trying to connect to it

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -26,7 +26,7 @@ FROM debian:buster
 
 # Install runtime dependencies
 RUN apt-get -qq update && \
-    apt-get -qq install --no-install-recommends binutils git ca-certificates netcat && \
+    apt-get -qq install --no-install-recommends binutils git ca-certificates netcat curl && \
     apt-get -qq autoremove && \
     apt-get -qq autoclean && \
     apt-get -qq clean all && \

--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -169,6 +169,15 @@ cat << EOF > /apiserver.json
 }
 EOF
 
+
+	# Wait for etcd to come online
+	echo -n "Waiting for etcd at $ETCD_ADDR..."
+	until $(curl -XGET --output /dev/null --silent --fail ${ETCD_ADDR}/version); do
+	    echo -n "."
+	    sleep 3 
+	done
+	echo -e "\netcd is online: $ETCD_ADDR"
+
 	if [ -z "$SPEC_GIT_REPO" ]; then 
 		SPEC_GIT_REPO=https://github.com/nds-org/ndslabs-specs
 	fi
@@ -185,7 +194,7 @@ EOF
 	umask 0
 
 	if [ -z "$TEST" ]; then
-		apiserver -conf /apiserver.json --logtostderr=true -v=1 -passwd $ADMIN_PASSWORD 
+		apiserver -conf /apiserver.json --logtostderr=true -v=4 -passwd $ADMIN_PASSWORD 
         else
                 echo "Running binary with test/coverage instrumentation"
                 echo "Writing output to $VOLUME_PATH/coverage.out"


### PR DESCRIPTION
## Problem
etcd sometimes takes a few seconds to startup. In the meantime, the `apiserver` goes into CrashLoopBackoff while attempting to connect to etcd.

## Approach
Use a simple bash loop to wait for etcd to startup before attempting to connect to it

## How to Test
1. Deploy the new image via the Helm chart
2. Check the logs of the `apiserver`: `kubectl logs -f deploy/workbench -c apiserver`
    * You should see that the `apiserver` waits for etcd to start before continuing its own startup