### PR TITLE
Improve error-handling around starting/stopping stacks

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -2022,7 +2022,11 @@ func (s *Server) startController(userId string, serviceKey string, stack *api.St
 	}
 	timeWait := time.Second * 0
 	for (ready + failed) < len(stack.Services) {
-		stck, _ := s.etcd.GetStack(userId, stack.Id)
+		stck, err := s.etcd.GetStack(userId, stack.Id)
+		if err != nil {
+			glog.Errorf("Failed to get stack from etcd: %s %s\n", userId, stack.Id)
+			return false, err
+		}
 		for _, ss := range stck.Services {
 			glog.V(4).Infof("Stack service %s: status=%s\n", ss.Id, ss.Status)
 			if ss.Status == "ready" {
@@ -2207,7 +2211,11 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 			break
 		}
 
-		stack, _ = s.getStackWithStatus(userId, sid)
+		stack, err := s.getStackWithStatus(userId, sid)
+		if err != nil {
+			glog.Errorf("Failed to get stack with status: %s %s\n", userId, sid)
+			return stack, err
+		}
 		for _, stackService := range stack.Services {
 			if stackService.Status == "error" {
 				errors[stackService.Service] = 1
@@ -2241,7 +2249,11 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 
 	ready := map[string]int{}
 	for len(ready) < len(started) && len(errors) == 0 {
-		stack, _ = s.getStackWithStatus(userId, sid)
+		stack, err := s.getStackWithStatus(userId, sid)
+		if err != nil {
+			glog.Errorf("Failed to get stack with status: %s %s\n", userId, sid)
+			return stack, err
+		}
 		for _, stackService := range stack.Services {
 			if stackService.Status == "ready" {
 				ready[stackService.Service] = 1
@@ -2253,9 +2265,15 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 		time.Sleep(time.Second * 3)
 	}
 
+	
+
 	// To overcome the 503 error on ingress, wait 5 seconds before returning the endpoint
 	time.Sleep(time.Second * 5)
-	stack, _ = s.getStackWithStatus(userId, sid)
+	stack, err := s.getStackWithStatus(userId, sid)
+	if err != nil {
+			glog.Errorf("Failed to get stack with status: %s %s\n", userId, sid)
+			return stack, err
+	}
 	stack.Status = "started"
 	for _, stackService := range stack.Services {
 		if stackService.Status == "error" || stackService.Status == "timeout" {
@@ -2271,9 +2289,10 @@ func (s *Server) startStack(userId string, stack *api.Stack) (*api.Stack, error)
 
 func (s *Server) getStackWithStatus(userId string, sid string) (*api.Stack, error) {
 
-	stack, _ := s.etcd.GetStack(userId, sid)
-	if stack == nil {
-		return nil, nil
+	stack, err := s.etcd.GetStack(userId, sid)
+	if err != nil {
+		glog.Errorf("Failed to get stack from etcd: %s %s\n", userId, sid)
+		return stack, err
 	}
 
 	for i := range stack.Services {
@@ -2363,7 +2382,11 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 	path := "/accounts/" + userId + "/stacks/" + sid
 	glog.V(4).Infof("Stopping stack %s\n", path)
 
-	stack, _ := s.etcd.GetStack(userId, sid)
+	stack, err := s.etcd.GetStack(userId, sid)
+	if err != nil {
+		glog.Errorf("Failed to get stack from etcd: %s %s\n", userId, sid)
+		return stack, err
+	}
 
 	glog.V(4).Infof("Stack status %s\n", stack.Status)
 	if stack.Status == stackStatus[Stopped] {
@@ -2379,7 +2402,11 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 	stopped := map[string]int{}
 
 	for len(stopped) < len(stack.Services) {
-		stack, _ = s.getStackWithStatus(userId, sid)
+		stack, err := s.getStackWithStatus(userId, sid)
+		if err != nil {
+			glog.Errorf("Failed to get stack from etcd: %s %s\n", userId, sid)
+			return stack, err
+		}
 		for _, stackService := range stack.Services {
 			spec, _ := s.etcd.GetServiceSpec(userId, stackService.Service)
 			name := fmt.Sprintf("%s-%s", stack.Id, spec.Key)
@@ -2434,7 +2461,11 @@ func (s *Server) stopStack(userId string, sid string) (*api.Stack, error) {
 	stack.Status = stackStatus[Stopped]
 	s.etcd.PutStack(userId, sid, stack)
 
-	stack, _ = s.getStackWithStatus(userId, sid)
+	stack, err = s.getStackWithStatus(userId, sid)
+	if err != nil {
+		glog.Errorf("Failed to get stack with status: %s %s\n", userId, sid)
+		return stack, err
+	}
 
 	/*
 		Disabling network policies per https://github.com/nds-org/ndslabs/issues/286


### PR DESCRIPTION
## Problem 
`apiserver` becomes very stable when starting or stopping stacks seemingly at random. My suspicion is that `etcd` sometimes gets overwhelmed and requests will timeout, as we occasionally see warnings of this in the logs. If not handled properly, these errors can crash the golang code.  

## Approach
Improve start/stop stack error-handling by simply ignoring these types of timeouts.

## How to Test
NOTE: Since the problem is intermittent, it is hard to reproduce reliably

1. Deploy this `workbench.image.apiserver` via the Helm chart: `ndslabs/apiserver:start-stop-error-handling`
2. Start and stop a bunch of stacks - really test out the system
    * You should get some warning about etcd header timeouts, but the `apiserver` should no longer crash and trigger a container restart