### PR TITLE
Fix ndslabsctl add account to also approve the new user

### DIFF
--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get -qq update && \
 
 # Copy final binaries from build container
 COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-*-amd64 /ndslabsctl/
+COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/ndslabsctl-linux-amd64 /usr/local/bin/ndslabsctl
 COPY --from=gobuild /go/src/github.com/ndslabs/apiserver/build/bin/apiserver-linux-amd64 /usr/local/bin/apiserver
 
 COPY entrypoint.sh /entrypoint.sh

--- a/apiserver/pkg/apictl/cmd/add.go
+++ b/apiserver/pkg/apictl/cmd/add.go
@@ -50,7 +50,7 @@ var addCmd = &cobra.Command{
 
 var addAccountCmd = &cobra.Command{
 	Use:    "account [name] [password]",
-	Short:  "Add the specified account (admin user only)",
+	Short:  "Add and approve the specified account (admin user only)",
 	PreRun: Connect,
 	Run: func(cmd *cobra.Command, args []string) {
 
@@ -67,6 +67,7 @@ var addAccountCmd = &cobra.Command{
 			account.Name = args[0]
 			account.Namespace = args[0]
 			account.Password = args[1]
+			account.Status = "approved"
 			//account.StorageQuota =
 			//account.Description =
 			//account.EmailAddress =


### PR DESCRIPTION
## Problem
Add account (admin only) creates users with a blank `status`.

Also, our golang imports/package names need to be updated to point at this new repo.

## Approach
* Set `status` to approved when using the admin-only `ndslabsctl add account` function
* Fix all of our locally-imported packages to point at new repo

## How to Test
1. Deploy the Helm chart with `workbench.images.apiserver=ndslabs/apiserver:fix-ndslabsctl-add-account`
2. Fetch the "admin" user password: `kubectl exec -it deploy/workbench -c apiserver -- cat password.txt`
    * Copy this password to your clipboard
3. Login as the admin user with this password: `kubectl exec -it deploy/workbench -c apiserver -- ndslabsctl login admin`
    * Paste the password from your clipboard
    * You should see "Login succeeded"
4. Add the demo account via file: `kubectl exec -it deploy/workbench -c apiserver -- ndslabsctl add account -f /templates/demo-account.json`
     * You should see "Added account demo"
     * You should be able to log into the Workbench UI with the credentials `demo:demo123`
5. Add a new account via CLI parameters: `kubectl exec -it deploy/workbench -c apiserver -- ndslabsctl add account testuser asdf1234`
     * You should see "Added account testuser"
     * You should be able to log into the Workbench UI with the credentials `testuser:asdf1234`