### PR TITLE
Add a demo account template inside the container

### DIFF
--- a/apiserver/templates/demo-account.json
+++ b/apiserver/templates/demo-account.json
@@ -1,0 +1,18 @@
+{ 
+    "id": "demo",
+    "name": "demo account",
+    "description": "demo account description",
+    "namespace": "demo",
+    "email": "devnull@ncsa.illinois.edu",
+    "password": "demo123",
+    "storageQuota": "10",
+    "status": "approved",
+    "resourceLimits": {
+	"cpuMax": 2000,
+	"cpuDefault": 1000,
+	"memMax": 8196,
+	"memDefault": 100,
+	"storageQuota": 10
+    }
+}
+


### PR DESCRIPTION
## Problem
Creating a demo account is a hassle

## Approach
Include a `templates/demo-account.json` in the container to make it easier to get a test user registered