### PR TITLE
Fix validation error in swagger.yaml

### DIFF
--- a/gui/swagger.yaml
+++ b/gui/swagger.yaml
@@ -332,8 +332,7 @@ paths:
       parameters:
         - in: query
           name: key
-          schema:
-            type: string
+          type: string
           required: true
           description: The key of the service spec to start and navigate to
       get:


### PR DESCRIPTION
## Problem
There was an error in schema validation for `swagger.yaml`

```
{"messages":["attribute paths.'/start'.[key].schema is unexpected","attribute paths.'/start'.[key].type is missing"],"schemaValidationMessages":[{"level":"error","domain":"validation","keyword":"oneOf","message":"instance failed to match exactly one schema (matched 0 out of 2)","schema":{"loadingURI":"http://swagger.io/v2/schema.json#","pointer":"/definitions/parametersList/items"},"instance":{"pointer":"/paths/~1start/parameters/0"}}]}
```

What this means is that `schema` should not be used in `/start`, as it does not point to a type that we have defined. Instead, to use the built-in `type` of `string`, we must not say we are specifying a schema.

## Approach
* Remove `schema.type` and use `type` directly