### PR TITLE
Strip special chars from username

### DIFF
--- a/apiserver/cmd/server/server.go
+++ b/apiserver/cmd/server/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"regexp"
 
 	"github.com/ndslabs/apiserver/pkg/config"
 	"github.com/ndslabs/apiserver/pkg/email"
@@ -592,6 +593,15 @@ func (s *Server) ValidateOAuth(w rest.ResponseWriter, r *rest.Request) {
 	if oauth_user == "" {
 		oauth_user = strings.Split(oauth_email, "@")[0]
 	}
+
+        // Make a Regex to say we only want letters and numbers
+        reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+        if err != nil {
+            glog.Fatal(err)
+	    w.WriteHeader(http.StatusUnauthorized)
+	    return
+        }
+        oauth_user = reg.ReplaceAllString(oauth_user, "")
 
 	// Fallback to Username if full name not available
 	oauth_name := oauth_fields["name"]

--- a/gui/dashboard/dashboard/dashboard.html
+++ b/gui/dashboard/dashboard/dashboard.html
@@ -110,7 +110,7 @@
                         <td>
                           <span tooltip-append-to-body="true" uib-tooltip="A friendly label for this application instance">{{ svc.service | specProperty:'label' }}</span>
 
-                          <a class="btn btn-link btn-sm" ng-repeat="endpt in svc.endpoints track by endpt.port" id="endpointLink"
+                          <a class="btn btn-primary btn-xs" ng-repeat="endpt in svc.endpoints track by endpt.port" id="endpointLink"
                               tooltip-append-to-body="true" uib-tooltip="Navigate to {{ svc.service | capitalize }} port {{ endpt.port }}"
                               ga-event-track="['application', 'endpoint', svc.key]"
                               ng-if="stack.status === 'started' && svc.status === 'ready' 


### PR DESCRIPTION
## Problem
When using OAuth, we take verbatim the user's username or email prefix as the Workbench username. This is problematic when the email address contains special characters, which are allowed as email addresses but not as the name of a k8s-namespace or resource

## Approach
Strip special chars from username before creating it in the system.

## How to Test
1. Sign-up a Google account with special chars in the username
2. Log into Workbench
3. Verify that namespace / PVC were created as expected
4. Launch an application to verify that account is working