### PR TITLE
Fix bad format when HelpLinks are not provided (default case)

### DIFF
--- a/gui/entrypoint.sh
+++ b/gui/entrypoint.sh
@@ -54,7 +54,7 @@ echo "{
     \"brandLogoPath\": \"${WORKBENCH_BRAND_LOGO_PATH:-../asset/png/favicon-32x32.png}\",
     \"faviconPath\": \"${WORKBENCH_FAVICON_PATH:-../asset/png/favicon-16x16.png}\",
     \"learnMoreUrl\": \"${WORKBENCH_LEARNMORE_URL:-http://www.nationaldataservice.org/platform/workbench.html}\",
-    \"helpLinks\": ${WORKBENCH_HELP_LINKS:-[]},
+    \"helpLinks\": ${WORKBENCH_HELP_LINKS:-[]}
   },
   \"advancedFeatures\": {
     \"showConfig\": ${SHOW_CONFIG:-false},

--- a/gui/entrypoint.sh
+++ b/gui/entrypoint.sh
@@ -7,25 +7,28 @@
 /bin/sed -i -e "s#^\.constant('ApiSecure', .*)#.constant('ApiSecure', ${APISERVER_SECURE:-true})#" "$BASEDIR/ConfigModule.js"
 /bin/sed -i -e "s#^\.constant('CookieOptions', .*#.constant('CookieOptions', { domain: '.${DOMAIN:-local.ndslabs.org}', secure: ${APISERVER_SECURE:-true}, path: '/' })#" "$BASEDIR/ConfigModule.js"
 
+
+
+### DEPRECATED: Start phasing out old pattern for passing in runtime envs
 # If provided, substitute UI customizations passed in by "docker run -e" or kubernetes
-if [ "${WORKBENCH_NAME}" != "" ]; then
-  /bin/sed -i -e "s#^\.constant('ProductName', .*)#.constant('ProductName', '${WORKBENCH_NAME}')#" "$BASEDIR/ConfigModule.js"
-fi
-if [ "${WORKBENCH_LANDING_HTML}" != "" ]; then
-  /bin/sed -i -e "s#^\.constant('ProductLandingHtml', .*)#.constant('ProductLandingHtml', '${WORKBENCH_LANDING_HTML}')#" "$BASEDIR/ConfigModule.js"
-fi
-if [ "${WORKBENCH_BRAND_LOGO_PATH}" != "" ]; then
-  /bin/sed -i -e "s#^\.constant('ProductBrandLogoPath', .*)#.constant('ProductBrandLogoPath', '${WORKBENCH_BRAND_LOGO_PATH}')#" "$BASEDIR/ConfigModule.js"
-fi
-if [ "${WORKBENCH_FAVICON_PATH}" != "" ]; then
-  /bin/sed -i -e "s#^\.constant('ProductFaviconPath', .*)#.constant('ProductFaviconPath', '${WORKBENCH_FAVICON_PATH}')#" "$BASEDIR/ConfigModule.js"
-fi
-if [ "${WORKBENCH_LEARNMORE_URL}" != "" ]; then
-  /bin/sed -i -e "s#^\.constant('ProductUrl', .*)#.constant('ProductUrl', '${WORKBENCH_LEARNMORE_URL}')#" "$BASEDIR/ConfigModule.js"
-fi
-if [ "${WORKBENCH_HELP_LINKS}" != "" ]; then
-  /bin/sed -i -e "s#^\.constant('HelpLinks', [])#.constant('HelpLinks', ${WORKBENCH_HELP_LINKS})#" "$BASEDIR/ConfigModule.js"
-fi
+#if [ "${WORKBENCH_NAME}" != "" ]; then
+#  /bin/sed -i -e "s#^\.constant('ProductName', .*)#.constant('ProductName', '${WORKBENCH_NAME}')#" "$BASEDIR/ConfigModule.js"
+#fi
+#if [ "${WORKBENCH_LANDING_HTML}" != "" ]; then
+#  /bin/sed -i -e "s#^\.constant('ProductLandingHtml', .*)#.constant('ProductLandingHtml', '${WORKBENCH_LANDING_HTML}')#" "$BASEDIR/ConfigModule.js"
+#fi
+#if [ "${WORKBENCH_BRAND_LOGO_PATH}" != "" ]; then
+#  /bin/sed -i -e "s#^\.constant('ProductBrandLogoPath', .*)#.constant('ProductBrandLogoPath', '${WORKBENCH_BRAND_LOGO_PATH}')#" "$BASEDIR/ConfigModule.js"
+#fi
+#if [ "${WORKBENCH_FAVICON_PATH}" != "" ]; then
+#  /bin/sed -i -e "s#^\.constant('ProductFaviconPath', .*)#.constant('ProductFaviconPath', '${WORKBENCH_FAVICON_PATH}')#" "$BASEDIR/ConfigModule.js"
+#fi
+#if [ "${WORKBENCH_LEARNMORE_URL}" != "" ]; then
+#  /bin/sed -i -e "s#^\.constant('ProductUrl', .*)#.constant('ProductUrl', '${WORKBENCH_LEARNMORE_URL}')#" "$BASEDIR/ConfigModule.js"
+#fi
+#if [ "${WORKBENCH_HELP_LINKS}" != "" ]; then
+#  /bin/sed -i -e "s#^\.constant('HelpLinks', [])#.constant('HelpLinks', ${WORKBENCH_HELP_LINKS})#" "$BASEDIR/ConfigModule.js"
+#fi
 
 # Substitute the SIGNIN_URL passed in by "docker run -e" or kubernetes
 /bin/sed -i -e "s#^\.constant('SigninUrl', .*)#.constant('SigninUrl', '${SIGNIN_URL:-https://www.local.ndslabs.org/login/}')#" "$BASEDIR/ConfigModule.js"

--- a/gui/entrypoint.sh
+++ b/gui/entrypoint.sh
@@ -49,12 +49,12 @@ fi
 
 echo "{
   \"product\": {
-    \"name\": \"${WORKBENCH_NAME}\",
-    \"landingHtml\": \"${WORKBENCH_LANDING_HTML}\",
-    \"brandLogoPath\": \"${WORKBENCH_BRAND_LOGO_PATH}\",
-    \"faviconPath\": \"${WORKBENCH_FAVICON_PATH}\",
-    \"learnMoreUrl\": \"${WORKBENCH_LEARNMORE_URL}\",
-    \"helpLinks\": ${WORKBENCH_HELP_LINKS}
+    \"name\": \"${WORKBENCH_NAME:-Workbench}\",
+    \"landingHtml\": \"${WORKBENCH_LANDING_HTML:-<p>Labs Workbench is an environment where developers can prototype tools and capabilities that help build out the NDS framework and services.</p>\n<p>In particular, it is a place that can host the development activities of <a href='http://www.nationaldataservice.org/projects/pilots.html'>NDS pilot projects.</a></p>\n}\",
+    \"brandLogoPath\": \"${WORKBENCH_BRAND_LOGO_PATH:-../asset/png/favicon-32x32.png}\",
+    \"faviconPath\": \"${WORKBENCH_FAVICON_PATH:-../asset/png/favicon-16x16.png}\",
+    \"learnMoreUrl\": \"${WORKBENCH_LEARNMORE_URL:-http://www.nationaldataservice.org/platform/workbench.html}\",
+    \"helpLinks\": ${WORKBENCH_HELP_LINKS:-[]},
   },
   \"advancedFeatures\": {
     \"showConfig\": ${SHOW_CONFIG:-false},


### PR DESCRIPTION
## Problem
If no HelpLinks were specified, the `env.json` produced is not valid. This causes anything that relies on env.json to fail:
* Poduct Name / navbar brand logo
* Help links
* Learn more button on landing page

## Approach
Use `[]` as default value in this case, instead of empty string
