### PR TITLE
Fix handling for defaultPath="/", configure apiserver loglevel at runtime

### DIFF
--- a/apiserver/entrypoint.sh
+++ b/apiserver/entrypoint.sh
@@ -192,7 +192,7 @@ EOF
 	umask 0
 
 	if [ -z "$TEST" ]; then
-		apiserver -conf /apiserver.json --logtostderr=true -v=2 -passwd $ADMIN_PASSWORD 
+		apiserver -conf /apiserver.json --logtostderr=true -v=${LOGLEVEL:-2} -passwd $ADMIN_PASSWORD 
         else
                 echo "Running binary with test/coverage instrumentation"
                 echo "Writing output to $VOLUME_PATH/coverage.out"


### PR DESCRIPTION
Issues found during migration / testing of the TERRA-REF Workbench

A feature was added in ~2017 to mount the user's entire PVC into their workbench app (defaultPath = "/")
eventually, defaultPath maps down to `subPath` in the Kubernetes volume spec

Sometime in ~2018, a vulnerability was discovered in Kubernetes that required `subPath` to be a relative path for security reasons. I suspect this this has been missed for so long because it is a unique edge case.

See https://opensource.ncsa.illinois.edu/jira/browse/NDS-970
See https://kubernetes.io/blog/2018/04/04/fixing-subpath-volume-vulnerability/